### PR TITLE
FIX: broken conda dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,18 +6,21 @@
 Before q2-fondue is available *via* conda, you can use the following instructions to install it on your machine:
 
 ```shell
-conda create -y -n fondue
+conda create -y -n fondue \
+   -c qiime2 -c conda-forge -c bioconda -c defaults \
+  qiime2 q2cli q2-types "entrezpy>=2.1.2" "sra-tools==2.9.6" xmltodict
 conda activate fondue
-conda install \
-  -c conda-forge -c bioconda -c qiime2 -c defaults \
-  qiime2 q2cli q2-types "entrezpy ~=2.1.2" "sra-tools ~=2.10.1" xmltodict
+
+pip install git+https://github.com/bokulich-lab/q2-fondue.git
+
+qiime dev refresh-cache
 ```
 
 The current q2-fondue version supports QIIME 2 **v2021.4** or higher.
 
-#### DEV note:
-Until QIIME 2 2021.4 is officially released, replace `-c qiime2` in the command above with
-`-c https://packages.qiime2.org/qiime2/2021.4/staged` to fetch the lastest dev version instead.
+#### DEV-only note:
+Until QIIME 2 2021.8 is officially released, replace `-c qiime2` in the command above with
+`-c https://packages.qiime2.org/qiime2/2021.8/staged` to fetch the latest dev version instead.
 
 ## Useful resources:
 * List of all available NCBI databases: 

--- a/ci/recipe/meta.yaml
+++ b/ci/recipe/meta.yaml
@@ -1,7 +1,7 @@
 # revert to proper versioning when ready for the first release
 {% set data = load_setup_py_data() %}
-{% set version = '2021.4.0.dev0' %}
-{% set release = '2021.4' %}
+{% set version = '2021.8.0.dev0' %}
+{% set release = '2021.8' %}
 
 package:
   name: q2-fondue
@@ -21,8 +21,8 @@ requirements:
   run:
     - python {{ python }}
     - xmltodict
-    - entrezpy ~=2.1.2
-    - sra-tools ~=2.10.1
+    - entrezpy >=2.1.2
+    - sra-tools ==2.9.6
     - q2-types {{ release }}.*
     - qiime2 {{ release }}.*
 


### PR DESCRIPTION
- fixes the CI run by reverting `sra-tools` to 2.9.6 (will need to review that at a later point since dependency resolution only works using a flexible solve but for now that's ok)
- small README tweaks
