### PR TITLE
FIX: simplify run creation

### DIFF
--- a/q2_fondue/entrezpy_clients/_sra_meta.py
+++ b/q2_fondue/entrezpy_clients/_sra_meta.py
@@ -143,7 +143,10 @@ class SRARun(SRABaseMeta):
     def __post_init__(self):
         """Calculates an average spot length."""
         super().__post_init__()
-        self.avg_spot_len = int(self.bases/self.spots)
+        if self.spots > 0:
+            self.avg_spot_len = int(self.bases/self.spots)
+        else:
+            self.avg_spot_len = 0
 
     def generate_meta(self) -> pd.DataFrame:
         """Generates run's metadata.

--- a/q2_fondue/metadata.py
+++ b/q2_fondue/metadata.py
@@ -118,7 +118,7 @@ def _get_run_meta(email, n_jobs, run_ids):
     # metadata will be fetched - in that case, keep running efetcher
     # until all runs are retrieved
     meta_df = [meta_df]
-    retries = 10
+    retries = 20
     while missing_ids and retries > 0:
         # TODO: add a logging statement here
         df, missing_ids = _execute_efetcher(email, n_jobs, missing_ids)

--- a/q2_fondue/tests/test_efetch.py
+++ b/q2_fondue/tests/test_efetch.py
@@ -72,48 +72,12 @@ class TestEfetchClients(_TestPluginWithEntrezFakeComponents):
         self.efetch_result_single.experiments[experiment_id] = exp_exp
 
         obs_id = self.efetch_result_single._create_single_run(
-            self.metadata_dict['Pool']['Member'],
-            run=self.metadata_dict['RUN_SET']['RUN'],
-            exp_id=experiment_id
+            self.metadata_dict,
+            exp_id=experiment_id,
+            desired_id='FAKEID1'
         )
 
         self.assertEqual('FAKEID1', obs_id)
-        self.assertEqual(1, len(self.efetch_result_single.runs))
-
-        obs_run = self.efetch_result_single.runs['FAKEID1']
-        self.assertEqual(exp_runs[0], obs_run)
-
-    def test_create_runs_single(self):
-        study_id, sample_id, = 'ERP120343', 'ERS4372624'
-        experiment_id, run_id = 'ERX3980916', 'FAKEID1'
-        exp_std, exp_samp, exp_exp, exp_runs = self.generate_sra_metadata()
-        self.efetch_result_single.studies[study_id] = exp_std
-        self.efetch_result_single.samples[sample_id] = exp_samp
-        self.efetch_result_single.experiments[experiment_id] = exp_exp
-
-        obs_ids = self.efetch_result_single._create_runs(
-            self.metadata_dict, exp_id=experiment_id,
-            sample_id=sample_id, desired_id=run_id)
-
-        self.assertListEqual(['FAKEID1'], obs_ids)
-        self.assertEqual(1, len(self.efetch_result_single.runs))
-
-        obs_run = self.efetch_result_single.runs['FAKEID1']
-        self.assertEqual(exp_runs[0], obs_run)
-
-    def test_create_runs_all(self):
-        study_id, sample_id, = 'ERP120343', 'ERS4372624'
-        experiment_id, _ = 'ERX3980916', ['FAKEID1']
-        exp_std, exp_samp, exp_exp, exp_runs = self.generate_sra_metadata()
-        self.efetch_result_single.studies[study_id] = exp_std
-        self.efetch_result_single.samples[sample_id] = exp_samp
-        self.efetch_result_single.experiments[experiment_id] = exp_exp
-
-        obs_ids = self.efetch_result_single._create_runs(
-            self.metadata_dict, exp_id=experiment_id,
-            sample_id=sample_id, desired_id=None)
-
-        self.assertListEqual(['FAKEID1'], obs_ids)
         self.assertEqual(1, len(self.efetch_result_single.runs))
 
         obs_run = self.efetch_result_single.runs['FAKEID1']

--- a/q2_fondue/tests/test_metadata.py
+++ b/q2_fondue/tests/test_metadata.py
@@ -243,7 +243,7 @@ class TestMetadataFetching(_TestPluginWithEntrezFakeComponents):
             {'meta1': [1, 2, 3], 'meta2': ['a', 'b', 'c']},
             index=['AB', 'cd', 'Ef']
         )
-        patch_ef.side_effect = [(exp_df, ['Ef']) for i in range(11)]
+        patch_ef.side_effect = [(exp_df, ['Ef']) for i in range(21)]
 
         with self.assertWarnsRegex(
                 Warning, 'could not be fetched: Ef. Please try fetching'):


### PR DESCRIPTION
Simplifies run creation by removal of unnecessary multi-run handling and changes extraction of some run-specific metadata to be fetched from another element of the Experiment Package (one that seems to be found in more metadata than the previous one).

~_Note to self:_ rebase after #37 is merged.~

Closes #36. 