### PR TITLE
FIX: Error raising in get-sequences

### DIFF
--- a/q2_fondue/sequences.py
+++ b/q2_fondue/sequences.py
@@ -7,6 +7,7 @@
 # ----------------------------------------------------------------------------
 
 import os
+import glob
 import re
 import gzip
 import warnings
@@ -69,7 +70,7 @@ def _run_fasterq_dump_for_all(
     for acc in sample_ids:
         result = _run_cmd_fasterq(acc, tmpdirname, threads, retries, logger)
 
-        if len(os.listdir(tmpdirname)) == 0:
+        if len(glob.glob(f"{tmpdirname}/{acc}*.fastq")) == 0:
             # raise error if all retries attempts failed
             raise ValueError('{} could not be downloaded with the '
                              'following fasterq-dump error '

--- a/q2_fondue/tests/test_sequences.py
+++ b/q2_fondue/tests/test_sequences.py
@@ -119,6 +119,20 @@ class TestUtils4SequenceFetching(SequenceTests):
             # check retry procedure:
             self.assertEqual(mock_subprocess.call_count, 2)
 
+    @patch('subprocess.run')
+    def test_run_fasterq_dump_for_all_error_twoids(self, mock_subprocess):
+        test_temp_dir = self.move_files_2_tmp_dir(['testaccA.fastq'])
+        ls_acc_ids = ['test_accERROR', 'testaccA']
+
+        with self.assertRaisesRegex(
+                ValueError, 'could not be downloaded with'):
+            _run_fasterq_dump_for_all(
+                ls_acc_ids, test_temp_dir.name, threads=6,
+                retries=1, logger=self.logger
+            )
+            # check retry procedure:
+            self.assertEqual(mock_subprocess.call_count, 3)
+
     def test_process_downloaded_sequences(self):
         ls_fastq_files = ['testaccA.fastq',
                           'testacc_1.fastq', 'testacc_2.fastq']


### PR DESCRIPTION
closes #43

Fix makes sure that `get-sequences` always raises error when one or more runIDs could not be fetched.
Previous behaviour: ValueError was not raised if at least one runID succeeded (see #43)