### PR TITLE
ENH: use progress bar to display download progress

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,7 +44,7 @@ jobs:
         auto-activate-base: false
     - name: run tests
       run: |
-        conda install -c conda-forge -c bioconda -c defaults -y "entrezpy>=2.1.2" "sra-tools>=2.11.0" xmltodict
+        conda install -c conda-forge -c bioconda -c defaults -y "entrezpy>=2.1.2" "sra-tools>=2.11.0" xmltodict "tqdm>=4.62.3"
         make dev
         qiime dev refresh-cache
         make test

--- a/README.md
+++ b/README.md
@@ -9,7 +9,8 @@ Before q2-fondue is available *via* conda, you can use the following instruction
 ```shell
 conda create -y -n fondue \
    -c qiime2 -c conda-forge -c bioconda -c defaults \
-  qiime2 q2cli q2-types "entrezpy>=2.1.2" "sra-tools>=2.11.0" xmltodict
+  qiime2 q2cli q2-types "entrezpy>=2.1.2" "sra-tools>=2.11.0" \
+  "tqdm>=4.62.3" xmltodict
 
 conda activate fondue
 ```

--- a/ci/recipe/meta.yaml
+++ b/ci/recipe/meta.yaml
@@ -21,6 +21,7 @@ requirements:
   run:
     - python {{ python }}
     - xmltodict
+    - tqdm >= 4.62.3
     - entrezpy >=2.1.2
     - sra-tools >= 2.11.0
     - q2-types {{ release }}.*


### PR DESCRIPTION
Printing every single accession ID while trying to fetch the corresponding sequences is not very helpful - on the contrary, when given hundreds of IDs it pollutes the logs unnecessarily. Additionally, in such case it's not very easy to follow the progress of the download. To address these points, a progress bar is introduced here (replacing that one log line) that will keep updating as the data is being downloaded. 