### PR TITLE
FIX: Change description in progress bar

### DIFF
--- a/q2_fondue/sequences.py
+++ b/q2_fondue/sequences.py
@@ -81,8 +81,8 @@ def _run_fasterq_dump_for_all(
         pbar = tqdm(sorted(accession_ids))
         for acc in pbar:
             pbar.set_description(
-                f'Downloading sequences for run {acc} '
-                f'(attempt {-retries + init_retries + 1})'
+                f'Attempt {-retries + init_retries + 1} out of '
+                f'{init_retries + 1} download progress'
             )
             result = _run_cmd_fasterq(
                 acc, tmpdirname, threads, logger)


### PR DESCRIPTION
Description in progress bar (introduced in #57) displayed initial run ID for all fetched accession IDs, e.g. when downloading 530 accession IDs it returned: `Downloading sequences for run ERR139017 (attempt 1):   1%|                    | 3/530 [03:37<10:01:12`. Here, I adjust this description to not include the initial run ID. 