### PR TITLE
FIX: properly use prefetch results while calling fasterq-dump

### DIFF
--- a/q2_fondue/sequences.py
+++ b/q2_fondue/sequences.py
@@ -32,25 +32,19 @@ threading.excepthook = handle_threaded_exception
 
 
 def _run_cmd_fasterq(
-        acc: str, output_dir: str, threads: int, logger):
+        acc: str, output_dir: str, threads: int):
     """
     Helper function running fasterq-dump
     """
-    cmd_prefetch = ["prefetch",
-                    "-O", output_dir,
-                    acc]
-    cmd_fasterq = ["fasterq-dump",
-                   "-O", output_dir,
-                   "-t", output_dir,
-                   "-e", str(threads),
-                   acc]
+    cmd_prefetch = ['prefetch', '-O', acc, acc]
+    cmd_fasterq = ['fasterq-dump', '-e', str(threads), acc]
 
-    result = subprocess.run(cmd_prefetch, text=True, capture_output=True)
+    result = subprocess.run(
+        cmd_prefetch, text=True, capture_output=True, cwd=output_dir)
 
-    if os.path.isfile(os.path.join(output_dir, f'{acc}.sra')) or \
-            os.path.isdir(os.path.join(output_dir, acc)):
-        result = subprocess.run(cmd_fasterq, text=True,
-                                capture_output=True)
+    if result.returncode == 0:
+        result = subprocess.run(
+            cmd_fasterq, text=True, capture_output=True, cwd=output_dir)
     return result
 
 
@@ -85,7 +79,7 @@ def _run_fasterq_dump_for_all(
                 f'(attempt {-retries + init_retries + 1})'
             )
             result = _run_cmd_fasterq(
-                acc, tmpdirname, threads, logger)
+                acc, tmpdirname, threads)
             if result.returncode != 0:
                 failed_ids[acc] = result.stderr
 
@@ -97,7 +91,7 @@ def _run_fasterq_dump_for_all(
                 index_next_acc = list(pbar).index(acc)+1
                 failed_ids_keys = list(pbar)[index_next_acc:]
                 failed_ids_error = len(failed_ids_keys) * \
-                    ["Storage exhausted."]
+                    ['Storage exhausted.']
                 failed_ids = dict(zip(failed_ids_keys, failed_ids_error))
                 # break retries
                 logger.info(

--- a/q2_fondue/tests/test_get_all.py
+++ b/q2_fondue/tests/test_get_all.py
@@ -45,7 +45,7 @@ class TestGetAll(SequenceTests):
         # define mocked return values for get_sequences mocks
         mock_tmpdir.return_value = self.move_files_2_tmp_dir(
             [f'{acc_id}.fastq', f'{acc_id}.sra'])
-        mock_subprocess.return_value = MagicMock(stderr=None)
+        mock_subprocess.return_value = MagicMock(returncode=0)
 
         # run pipeline
         fondue.actions.get_all(test_md, 'fake@email.com', retries=1)
@@ -62,11 +62,10 @@ class TestGetAll(SequenceTests):
 
         # function call assertions for get_sequences within
         mock_subprocess.assert_has_calls([
-            call(['prefetch', '-O', ANY, acc_id],
-                 text=True, capture_output=True),
-            call(['fasterq-dump', '-O', ANY,
-                  '-t', ANY, '-e', '1', acc_id],
-                 text=True, capture_output=True)
+            call(['prefetch', '-O', acc_id,  acc_id],
+                 text=True, capture_output=True, cwd=ANY),
+            call(['fasterq-dump', '-e', '1', acc_id],
+                 text=True, capture_output=True, cwd=ANY)
         ])
 
 

--- a/q2_fondue/tests/test_sequences.py
+++ b/q2_fondue/tests/test_sequences.py
@@ -96,23 +96,18 @@ class TestUtils4SequenceFetching(SequenceTests):
                                                    'testaccA.sra'])
 
         ls_acc_ids = ['testaccA']
-
-        exp_prefetch = ['prefetch',
-                        '-O', test_temp_dir.name,
-                        ls_acc_ids[0]]
-        exp_fasterq = ['fasterq-dump',
-                       '-O', test_temp_dir.name,
-                       "-t", test_temp_dir.name,
-                       "-e", str(6),
-                       ls_acc_ids[0]]
+        exp_prefetch = ['prefetch', '-O', ls_acc_ids[0], ls_acc_ids[0]]
+        exp_fasterq = ['fasterq-dump', '-e', str(6), ls_acc_ids[0]]
 
         _run_fasterq_dump_for_all(
             ls_acc_ids, test_temp_dir.name, threads=6,
             retries=0, logger=self.fake_logger
         )
         mock_subprocess.assert_has_calls([
-            call(exp_prefetch, text=True, capture_output=True),
-            call(exp_fasterq, text=True, capture_output=True)
+            call(exp_prefetch, text=True,
+                 capture_output=True, cwd=test_temp_dir.name),
+            call(exp_fasterq, text=True,
+                 capture_output=True, cwd=test_temp_dir.name)
         ])
 
     @patch('subprocess.run', return_value=MagicMock(returncode=0))
@@ -121,23 +116,18 @@ class TestUtils4SequenceFetching(SequenceTests):
         os.makedirs(f'{test_temp_dir.name}/testaccA')
 
         ls_acc_ids = ['testaccA']
-
-        exp_prefetch = ['prefetch',
-                        '-O', test_temp_dir.name,
-                        ls_acc_ids[0]]
-        exp_fasterq = ['fasterq-dump',
-                       '-O', test_temp_dir.name,
-                       "-t", test_temp_dir.name,
-                       "-e", str(6),
-                       ls_acc_ids[0]]
+        exp_prefetch = ['prefetch', '-O', ls_acc_ids[0], ls_acc_ids[0]]
+        exp_fasterq = ['fasterq-dump', '-e', str(6), ls_acc_ids[0]]
 
         _run_fasterq_dump_for_all(
             ls_acc_ids, test_temp_dir.name, threads=6,
             retries=0, logger=self.fake_logger
         )
         mock_subprocess.assert_has_calls([
-            call(exp_prefetch, text=True, capture_output=True),
-            call(exp_fasterq, text=True, capture_output=True)
+            call(exp_prefetch, text=True,
+                 capture_output=True, cwd=test_temp_dir.name),
+            call(exp_fasterq, text=True,
+                 capture_output=True, cwd=test_temp_dir.name)
         ])
 
     @patch('subprocess.run', return_value=MagicMock(returncode=0))
@@ -145,23 +135,19 @@ class TestUtils4SequenceFetching(SequenceTests):
         test_temp_dir = self.move_files_2_tmp_dir(['testaccA.fastq',
                                                    'testaccA.sra'])
         ls_acc_ids = ['testaccA']
+        exp_prefetch = ['prefetch', '-O', ls_acc_ids[0], ls_acc_ids[0]]
+        exp_fasterq = ['fasterq-dump', '-e', str(6), ls_acc_ids[0]]
 
-        exp_prefetch = ['prefetch',
-                        '-O', test_temp_dir.name,
-                        ls_acc_ids[0]]
-        exp_fasterq = ['fasterq-dump',
-                       '-O', test_temp_dir.name,
-                       "-t", test_temp_dir.name,
-                       "-e", str(6),
-                       ls_acc_ids[0]]
         with self.assertLogs('test_log', level='INFO') as cm:
             failed_ids = _run_fasterq_dump_for_all(
                 ls_acc_ids, test_temp_dir.name, threads=6,
                 retries=0, logger=self.fake_logger
             )
             mock_subprocess.assert_has_calls([
-                call(exp_prefetch, text=True, capture_output=True),
-                call(exp_fasterq, text=True, capture_output=True)
+                call(exp_prefetch, text=True,
+                     capture_output=True, cwd=test_temp_dir.name),
+                call(exp_fasterq, text=True,
+                     capture_output=True, cwd=test_temp_dir.name)
             ])
             self.assertEqual(len(failed_ids), 0)
             self.assertIn(
@@ -429,7 +415,8 @@ class TestSequenceFetching(SequenceTests):
         test_temp_md = self.prepare_metadata('testaccBC')
 
         mock_subprocess.side_effect = [
-            MagicMock(returncode=0),
+            MagicMock(returncode=0), MagicMock(returncode=0),
+            MagicMock(returncode=1, stderr='Some error'),
             MagicMock(returncode=1, stderr='Some error')
         ]
 


### PR DESCRIPTION
It turns out that until now the results and benefits of `prefetch` were not really used by `fasterq-dump` and so the sequences would be always fetched twice. The reason for this is that when `prefetch` saves results in non-default directories (like we were doing), `fasterq-dump` has no knowledge of where those are so it just re-fetches everything again. 

This PR fixes that by adjusting the working directory when executing both commands.