### PR TITLE
FIX: merge duplicated metadata columns

### DIFF
--- a/q2_fondue/entrezpy_clients/_efetch.py
+++ b/q2_fondue/entrezpy_clients/_efetch.py
@@ -16,9 +16,10 @@ from entrezpy.base.result import EutilsResult
 from xmltodict import parse as parsexml
 
 from q2_fondue.entrezpy_clients._utils import (rename_columns, set_up_logger)
-from q2_fondue.entrezpy_clients._sra_meta import (LibraryMetadata, SRARun,
-                                                  SRAExperiment, SRASample,
-                                                  SRAStudy)
+from q2_fondue.entrezpy_clients._sra_meta import (
+    LibraryMetadata, SRARun, SRAExperiment, SRASample, SRAStudy,
+    META_REQUIRED_COLUMNS
+)
 
 
 class EFetchResult(EutilsResult):
@@ -75,13 +76,11 @@ class EFetchResult(EutilsResult):
         # clean up column names
         df = rename_columns(df)
 
+        # remove potential column duplicates
+        df = df.groupby(level=0, axis=1).first()
+
         # reorder columns in a more sensible fashion
-        cols = [
-            'Experiment ID', 'Biosample ID', 'Bioproject ID', 'Study ID',
-            'Sample Accession', 'Organism', 'Library Source', 'Library Layout',
-            'Library Selection', 'Instrument', 'Platform', 'Bases', 'Spots',
-            'Avg Spot Len', 'Bytes', 'Public'
-        ]
+        cols = META_REQUIRED_COLUMNS.copy()
         cols.extend([c for c in df.columns if c not in cols])
 
         return df[cols]

--- a/q2_fondue/entrezpy_clients/_sra_meta.py
+++ b/q2_fondue/entrezpy_clients/_sra_meta.py
@@ -15,6 +15,14 @@ import pandas as pd
 from q2_fondue.entrezpy_clients._utils import get_attrs
 
 
+META_REQUIRED_COLUMNS = [
+    'Experiment ID', 'Biosample ID', 'Bioproject ID', 'Study ID',
+    'Sample Accession', 'Organism', 'Library Source', 'Library Layout',
+    'Library Selection', 'Instrument', 'Platform', 'Bases', 'Spots',
+    'Avg Spot Len', 'Bytes', 'Public'
+]
+
+
 @dataclass
 class LibraryMetadata:
     """A class for storing sequencing library metadata."""


### PR DESCRIPTION
In a rather rare situation where metadata from two different studies contain the same column name but spelled slightly differently (e.g., `isolate` vs. `Isolate`) metadata fetch would result in a DataFrame concatenation error (here: https://github.com/bokulich-lab/q2-fondue/blob/e39db49211b5bf3ce5c2dd74e65b12a5b61834a4/q2_fondue/metadata.py#L102). 

This PR introduces an additional de-duplication step to merge those columns together before concatenating all the metadata from multiple re-fetches.