### PR TITLE
FIX: use alternative spots location in run metadata

### DIFF
--- a/q2_fondue/entrezpy_clients/_efetch.py
+++ b/q2_fondue/entrezpy_clients/_efetch.py
@@ -318,10 +318,18 @@ class EFetchResult(EutilsResult):
     @staticmethod
     def _get_pool_meta_from_run(run: dict) -> dict:
         """Extracts base and spot count from run metadata."""
-        bases, stats = run.get('Bases'), run.get('Statistics')
+        bases = run.get('@total_bases')
+        spots = run.get('@total_spots')
         size = run.get('@size', 0)
-        bases = bases.get('@count', run.get('@total_bases', 0))
-        spots = stats.get('@nspots', run.get('@total_spots', 0))
+
+        if not bases:
+            bases = run.get('Bases')
+            bases = bases.get('@count', 0) if bases else 0
+
+        if not spots:
+            stats = run.get('Statistics')
+            spots = stats.get('@nspots', 0) if stats else 0
+
         return {'bases': bases, 'spots': spots, 'size': size}
 
     def _process_single_id(

--- a/q2_fondue/tests/test_efetch.py
+++ b/q2_fondue/tests/test_efetch.py
@@ -51,18 +51,8 @@ class TestEfetchClients(_TestPluginWithEntrezFakeComponents):
 
     def test_efetch_get_pool_meta(self):
         run = {
-            'Bases': {'@count': 123}, 'Statistics': {'@nspots': 12},
-            '@total_bases': 345, '@total_spots': 567, '@size': 456
-        }
-
-        obs_meta = self.efetch_result_single._get_pool_meta_from_run(run)
-        exp_meta = {'bases': 123, 'spots': 12, 'size': 456}
-        self.assertDictEqual(exp_meta, obs_meta)
-
-    def test_efetch_get_pool_meta_missing_bases(self):
-        run = {
-            'Bases': {}, 'Statistics': {'@nspots': 12},
-            '@total_bases': 345, '@total_spots': 567, '@size': 456
+            'Bases': {'@count': 345}, 'Statistics': {'@nspots': 12},
+            '@total_bases': 345, '@total_spots': 12, '@size': 456
         }
 
         obs_meta = self.efetch_result_single._get_pool_meta_from_run(run)
@@ -71,42 +61,59 @@ class TestEfetchClients(_TestPluginWithEntrezFakeComponents):
 
     def test_efetch_get_pool_meta_missing_total_bases(self):
         run = {
-            'Bases': {}, 'Statistics': {'@nspots': 12},
-            '@total_spots': 567, '@size': 456
+            'Bases': {'@count': 345}, 'Statistics': {'@nspots': 12},
+            '@total_spots': 12, '@size': 456
+        }
+
+        obs_meta = self.efetch_result_single._get_pool_meta_from_run(run)
+        exp_meta = {'bases': 345, 'spots': 12, 'size': 456}
+        self.assertDictEqual(exp_meta, obs_meta)
+
+    def test_efetch_get_pool_meta_missing_bases(self):
+        run = {
+            'Statistics': {'@nspots': 12},
+            '@total_spots': 12, '@size': 456
         }
 
         obs_meta = self.efetch_result_single._get_pool_meta_from_run(run)
         exp_meta = {'bases': 0, 'spots': 12, 'size': 456}
         self.assertDictEqual(exp_meta, obs_meta)
 
-    def test_efetch_get_pool_meta_missing_nspots(self):
-        run = {
-            'Bases': {'@count': 123}, 'Statistics': {},
-            '@total_bases': 345, '@total_spots': 567, '@size': 456
-        }
-
-        obs_meta = self.efetch_result_single._get_pool_meta_from_run(run)
-        exp_meta = {'bases': 123, 'spots': 567, 'size': 456}
-        self.assertDictEqual(exp_meta, obs_meta)
-
     def test_efetch_get_pool_meta_missing_total_spots(self):
         run = {
-            'Bases': {'@count': 123}, 'Statistics': {},
+            'Bases': {'@count': 345}, 'Statistics': {'@nspots': 12},
             '@total_bases': 345, '@size': 456
         }
 
         obs_meta = self.efetch_result_single._get_pool_meta_from_run(run)
-        exp_meta = {'bases': 123, 'spots': 0, 'size': 456}
+        exp_meta = {'bases': 345, 'spots': 12, 'size': 456}
+        self.assertDictEqual(exp_meta, obs_meta)
+
+    def test_efetch_get_pool_meta_missing_stats(self):
+        run = {
+            'Bases': {'@count': 345},
+            '@total_bases': 345, '@size': 456
+        }
+
+        obs_meta = self.efetch_result_single._get_pool_meta_from_run(run)
+        exp_meta = {'bases': 345, 'spots': 0, 'size': 456}
         self.assertDictEqual(exp_meta, obs_meta)
 
     def test_efetch_get_pool_meta_missing_size(self):
         run = {
-            'Bases': {'@count': 123}, 'Statistics': {'@nspots': 12},
-            '@total_bases': 345, '@total_spots': 567
+            'Bases': {'@count': 345}, 'Statistics': {'@nspots': 12},
+            '@total_bases': 345, '@total_spots': 12
         }
 
         obs_meta = self.efetch_result_single._get_pool_meta_from_run(run)
-        exp_meta = {'bases': 123, 'spots': 12, 'size': 0}
+        exp_meta = {'bases': 345, 'spots': 12, 'size': 0}
+        self.assertDictEqual(exp_meta, obs_meta)
+
+    def test_efetch_get_pool_meta_missing_all(self):
+        run = {}
+
+        obs_meta = self.efetch_result_single._get_pool_meta_from_run(run)
+        exp_meta = {'bases': 0, 'spots': 0, 'size': 0}
         self.assertDictEqual(exp_meta, obs_meta)
 
     def test_efetch_create_experiment(self):


### PR DESCRIPTION
In an even rarer situation where run's metadata does not contain spot information in the `Statistics` dictionary metadata fetch would fail. 

This PR rewrites slightly the `_get_pool_meta_from_run` to search for the missing data in other locations.

Can be tested using `ERR7834945` as an example for some of the missing fields.