### PR TITLE
FIX: extract missing experiment metadata

### DIFF
--- a/q2_fondue/entrezpy_clients/_efetch.py
+++ b/q2_fondue/entrezpy_clients/_efetch.py
@@ -261,13 +261,16 @@ class EFetchResult(EutilsResult):
         if exp_id not in self.experiments.keys():
             platform = list(exp_meta['PLATFORM'].keys())[0]
             instrument = exp_meta['PLATFORM'][platform].get('INSTRUMENT_MODEL')
+            custom_meta = self._extract_custom_attributes(
+                exp_meta, 'experiment'
+            )
             self.experiments[exp_id] = SRAExperiment(
                 id=exp_id,
                 instrument=instrument,
                 platform=platform,
                 sample_id=sample_id,
                 library=self._extract_library_info(attributes),
-                custom_meta=None
+                custom_meta=custom_meta
             )
             # append experiment to sample
             self.samples[sample_id].experiments.append(

--- a/q2_fondue/tests/_utils.py
+++ b/q2_fondue/tests/_utils.py
@@ -131,7 +131,9 @@ class _TestPluginWithEntrezFakeComponents(TestPluginBase):
         )
         experiment = SRAExperiment(
             id=experiment_id, instrument='Illumina MiSeq', platform='ILLUMINA',
-            library=self.library_meta, sample_id=sample_id, custom_meta=None
+            library=self.library_meta, sample_id=sample_id, custom_meta={
+                'Temperature [EXPERIMENT]': '12', 'Depth [EXPERIMENT]': '500'
+            }
         )
         runs = [SRARun(
             id=_id, bases=11552099, spots=39323, public=True, bytes=3914295,

--- a/q2_fondue/tests/data/metadata_response_small.json
+++ b/q2_fondue/tests/data/metadata_response_small.json
@@ -43,7 +43,19 @@
       "ILLUMINA": {
         "INSTRUMENT_MODEL": "Illumina MiSeq"
       }
-    }
+    },
+    "EXPERIMENT_ATTRIBUTES": {
+        "EXPERIMENT_ATTRIBUTE": [
+          {
+            "TAG": "Temperature",
+            "VALUE": "12"
+          },
+          {
+            "TAG": "Depth",
+            "VALUE": "500"
+          }
+        ]
+      }
   },
   "SUBMISSION": {
     "@accession": "ERA2402167",


### PR DESCRIPTION
This PR adds the missing step of extracting experiment metadata. See issue description for testing details.

Closes #85. 