### PR TITLE
ENH: Improved metadata fetching and error logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ To find out which temporary directory is used by Qiime 2, you can run `echo $TMP
 
 ## Usage
 ### Available actions
-q2-fondue provides a couple of actions to fetch and manipulate nucleotide sequencing data and related metadata from SRA as well as an action to scrape run, study, BioProject, experiment and study IDs from a Zotero web library. Below you will find a list of available actions and their short descriptions.
+q2-fondue provides a couple of actions to fetch and manipulate nucleotide sequencing data and related metadata from SRA as well as an action to scrape run, study, BioProject, experiment and sample IDs from a Zotero web library. Below you will find a list of available actions and their short descriptions.
 
 | Action           | Description                                                              |
 |------------------|--------------------------------------------------------------------------|

--- a/q2_fondue/entrezpy_clients/_efetch.py
+++ b/q2_fondue/entrezpy_clients/_efetch.py
@@ -7,7 +7,6 @@
 # ----------------------------------------------------------------------------
 
 import json
-from itertools import chain
 from typing import List, Union
 
 import pandas as pd
@@ -494,7 +493,7 @@ class EFetchResult(EutilsResult):
         for i, uid in enumerate(uids):
             if uid in found_uids:
                 current_run = run_ids_map[uid]
-                self.metadata[i] = self._process_single_id(
+                self.metadata += self._process_single_id(
                     parsed_results[current_run], desired_id=uid)
 
 
@@ -529,7 +528,6 @@ class EFetchAnalyzer(EutilsAnalyzer):
 
     # override the base method to enable parsing when retmode=text
     def parse(self, raw_response, request):
-        # todo: solve error if retmax/10'000 much larger than # run IDs
         response = self.convert_response(
             raw_response.read().decode('utf-8'), request)
         if self.isErrorResponse(response, request):

--- a/q2_fondue/entrezpy_clients/_efetch.py
+++ b/q2_fondue/entrezpy_clients/_efetch.py
@@ -542,7 +542,5 @@ class EFetchAnalyzer(EutilsAnalyzer):
         if self.isErrorResponse(response, request):
             self.hasErrorResponse = True
             self.analyze_error(response, request)
-            if self.error_msg == '':
-                self.error_msg = raw_response.msg
         else:
             self.analyze_result(response, request)

--- a/q2_fondue/entrezpy_clients/_esearch.py
+++ b/q2_fondue/entrezpy_clients/_esearch.py
@@ -152,8 +152,6 @@ def get_run_id_count(
     Returns:
         int: Number of run IDs associated with provided ids.
     """
-    # not testing as it's already tested individually - might require
-    # tests in future
     esearch_count = searcher.Esearcher(
         'esearcher', email, apikey=None,
         apikey_var=None, threads=n_jobs, qid=None)

--- a/q2_fondue/entrezpy_clients/_esearch.py
+++ b/q2_fondue/entrezpy_clients/_esearch.py
@@ -13,6 +13,7 @@ import pandas as pd
 from entrezpy.base.analyzer import EutilsAnalyzer
 from entrezpy.base.result import EutilsResult
 from q2_fondue.entrezpy_clients._utils import set_up_logger
+import entrezpy.esearch.esearcher as searcher
 
 
 class ESearchResult(EutilsResult):
@@ -136,3 +137,29 @@ class ESearchAnalyzer(EutilsAnalyzer):
     def analyze_result(self, response, request):
         self.init_result(response, request)
         self.result.parse_search_results(response, self.uids)
+
+
+def get_run_id_count(
+        email: str, n_jobs: int, ids: list, log_level: str) -> int:
+    """Returns number of run IDs for provided ids.
+
+    Args:
+        email (str): User email.
+        n_jobs (int): Number of jobs.
+        ids (list): List of study, bioproject, sample or experiment IDs.
+        log_level (str): The log level to set.
+
+    Returns:
+        int: Number of run IDs associated with provided ids.
+    """
+    # not testing as it's already tested individually - might require
+    # tests in future
+    esearch_count = searcher.Esearcher(
+        'esearcher', email, apikey=None,
+        apikey_var=None, threads=n_jobs, qid=None)
+    esearch_response = esearch_count.inquire(
+        {'db': 'sra', 'term': " OR ".join(ids)},
+        analyzer=ESearchAnalyzer(ids, log_level))
+    nb_runs = esearch_response.result.result.sum()
+    del esearch_response
+    return nb_runs

--- a/q2_fondue/entrezpy_clients/_esearch.py
+++ b/q2_fondue/entrezpy_clients/_esearch.py
@@ -159,5 +159,5 @@ def get_run_id_count(
         {'db': 'sra', 'term': " OR ".join(ids)},
         analyzer=ESearchAnalyzer(ids, log_level))
     nb_runs = esearch_response.result.result.sum()
-    del esearch_response
+    del esearch_response, esearch_count
     return nb_runs

--- a/q2_fondue/entrezpy_clients/_pipelines.py
+++ b/q2_fondue/entrezpy_clients/_pipelines.py
@@ -13,9 +13,11 @@ from q2_fondue.entrezpy_clients._elink import ELinkAnalyzer
 from q2_fondue.entrezpy_clients._esearch import ESearchAnalyzer
 from q2_fondue.entrezpy_clients._utils import set_up_entrezpy_logging
 
+RUN_RETMAX = 1000
+
 
 def _get_run_ids(
-        email: str, n_jobs: int, ids: list, source: str,
+        email: str, n_jobs: int, step: int, ids: list, source: str,
         log_level: str) -> list:
     """Pipeline to retrieve metadata of run IDs associated with
     studies (`source`='study') or bioprojects (`source`='bioproject')
@@ -24,7 +26,9 @@ def _get_run_ids(
     Args:
         email (str): User email.
         n_jobs (int): Number of jobs.
-        ids (list): list of study or bioproject IDs.
+        step (int): Count on how frequently run IDs were already fetched
+                    before.
+        ids (list): List of study, bioproject, sample or experiment IDs.
         source (str): Type of IDs provided ('study', 'bioproject',
                       'sample' or 'experiment').
         log_level (str): The log level to set.
@@ -58,9 +62,12 @@ def _get_run_ids(
     else:
         el = es
 
-    # given SRA run IDs, fetch all metadata
+    # given SRA run IDs, fetch all metadata - using retmax + retstart to
+    # fetch all available run IDs (source:
+    # https://dataguide.nlm.nih.gov/eutilities/utilities.html#efetch)
     samp_ids_pipeline.add_fetch(
-        {'rettype': 'docsum', 'retmode': 'xml', 'retmax': 10000},
+        {'rettype': 'docsum', 'retmode': 'xml', 'retmax': RUN_RETMAX,
+         'retstart': 0 + step * RUN_RETMAX},
         analyzer=EFetchAnalyzer(log_level), dependency=el
     )
 

--- a/q2_fondue/entrezpy_clients/_pipelines.py
+++ b/q2_fondue/entrezpy_clients/_pipelines.py
@@ -15,7 +15,7 @@ from q2_fondue.entrezpy_clients._utils import set_up_entrezpy_logging
 
 
 def _get_run_ids(
-        email: str, n_jobs: int, retmax: int, step: int, ids: list,
+        email: str, n_jobs: int, retmax: int, ids: list,
         source: str, log_level: str) -> list:
     """Pipeline to retrieve metadata of run IDs associated with
     studies (`source`='study'), bioprojects (`source`='bioproject'),
@@ -26,8 +26,6 @@ def _get_run_ids(
         email (str): User email.
         n_jobs (int): Number of jobs.
         retmax (int): Number of IDs to get in one fetch.
-        step (int): Count on how frequently run IDs were already fetched
-                    before.
         ids (list): List of study, bioproject, sample or experiment IDs.
         source (str): Type of IDs provided ('study', 'bioproject',
                       'sample' or 'experiment').
@@ -62,16 +60,13 @@ def _get_run_ids(
     else:
         el = es
 
-    # given SRA run IDs, fetch all metadata - using retmax + retstart to
-    # fetch all available run IDs (source:
-    # https://dataguide.nlm.nih.gov/eutilities/utilities.html#efetch)
+    # given SRA run IDs, fetch all metadata
     samp_ids_pipeline.add_fetch(
-        {'rettype': 'docsum', 'retmode': 'xml', 'retmax': retmax,
-         'retstart': 0 + step * retmax},
+        {'rettype': 'docsum', 'retmode': 'xml', 'retmax': retmax},
         analyzer=EFetchAnalyzer(log_level), dependency=el
     )
 
     a = econduit.run(samp_ids_pipeline)
     # deleting conduit object to avoid thread error
     del econduit
-    return a.result.metadata_to_series().tolist()
+    return a.result.metadata

--- a/q2_fondue/entrezpy_clients/_pipelines.py
+++ b/q2_fondue/entrezpy_clients/_pipelines.py
@@ -10,9 +10,9 @@ from entrezpy import conduit as ec
 import math
 from q2_fondue.entrezpy_clients._efetch import EFetchAnalyzer
 from q2_fondue.entrezpy_clients._elink import ELinkAnalyzer
-from q2_fondue.entrezpy_clients._esearch import ESearchAnalyzer
+from q2_fondue.entrezpy_clients._esearch import (
+    ESearchAnalyzer, get_run_id_count)
 from q2_fondue.entrezpy_clients._utils import set_up_entrezpy_logging
-import entrezpy.esearch.esearcher as searcher
 
 
 def _get_run_ids(
@@ -34,17 +34,9 @@ def _get_run_ids(
     Returns:
         list: Run IDs associated with provided ids.
     """
-    # get retmax number
-    esearch_count = searcher.Esearcher(
-        'esearcher', email, apikey=None,
-        apikey_var=None, threads=n_jobs, qid=None)
-    esearch_response = esearch_count.inquire(
-            {'db': 'sra', 'term': " OR ".join(ids)},
-            analyzer=ESearchAnalyzer(ids, log_level))
-    nb_runs = esearch_response.result.result.sum()
+    nb_runs = get_run_id_count(email, n_jobs, ids, log_level)
     # source for rounding up to next 1k: https://stackoverflow.com/a/8866125
     retmax = int(math.ceil(nb_runs / 10000.0)) * 10000
-    del esearch_response
 
     # create pipeline to fetch all run IDs
     if source == 'bioproject':

--- a/q2_fondue/metadata.py
+++ b/q2_fondue/metadata.py
@@ -25,7 +25,7 @@ from q2_fondue.entrezpy_clients._pipelines import _get_run_ids
 
 threading.excepthook = handle_threaded_exception
 BATCH_SIZE = 150
-RUN_RETMAX = 1000
+RUN_RETMAX = 10000  # todo: set even higher: > 40'000
 
 
 def _chunker(seq, size):
@@ -128,19 +128,9 @@ def _get_run_meta(
 def _get_other_meta(
         email, n_jobs, project_ids, id_type, log_level, logger
 ) -> (pd.DataFrame, dict):
-    i = 0
-    run_ids = []
-    more_needed = True
-
-    while more_needed:
-        batch_run_ids = _get_run_ids(
-                    email, n_jobs, RUN_RETMAX, i, project_ids,
+    run_ids = _get_run_ids(
+                    email, n_jobs, RUN_RETMAX, project_ids,
                     id_type, log_level)
-        i += 1
-        run_ids += batch_run_ids
-        # if batch_run_ids==RUN_RETMAX, there might be more run IDs to fetch
-        if len(batch_run_ids) != RUN_RETMAX:
-            more_needed = False
 
     return _get_run_meta(email, n_jobs, run_ids, log_level, logger)
 

--- a/q2_fondue/metadata.py
+++ b/q2_fondue/metadata.py
@@ -143,7 +143,8 @@ def get_metadata(
 
     Returns:
         pd.DataFrame: DataFrame with metadata obtained for the provided IDs.
-        pd.DataFrame: DataFrame with invalid IDs and their descriptions.
+        pd.DataFrame: DataFrame with runs IDs for which no metadata was
+            fetched and the associated error messages.
     """
     logger = set_up_logger(log_level, logger_name=__name__)
 

--- a/q2_fondue/metadata.py
+++ b/q2_fondue/metadata.py
@@ -15,7 +15,7 @@ from qiime2 import Metadata
 
 from q2_fondue.entrezpy_clients._efetch import EFetchAnalyzer
 from q2_fondue.utils import (
-    _validate_esearch_result, _determine_id_type, handle_threaded_exception,
+    _validate_run_ids, _determine_id_type, handle_threaded_exception,
     _chunker
 )
 from q2_fondue.entrezpy_clients._utils import (set_up_entrezpy_logging,
@@ -51,9 +51,8 @@ def _efetcher_inquire(
     )
 
     if metadata_response.result is None:
-        error_msg = metadata_response.error_msg
         return (pd.DataFrame(),
-                {m_id: error_msg for m_id in run_ids})
+                {m_id: metadata_response.error_msg for m_id in run_ids})
     else:
         return (metadata_response.result.metadata_to_df(), {})
 
@@ -84,7 +83,7 @@ def _execute_efetcher(email, n_jobs, run_ids, log_level, logger):
 def _get_run_meta(
         email, n_jobs, run_ids, log_level, logger
 ) -> (pd.DataFrame, dict):
-    invalid_ids = _validate_esearch_result(email, n_jobs, run_ids, log_level)
+    invalid_ids = _validate_run_ids(email, n_jobs, run_ids, log_level)
     valid_ids = sorted(list(set(run_ids) - set(invalid_ids.keys())))
 
     if not valid_ids:

--- a/q2_fondue/metadata.py
+++ b/q2_fondue/metadata.py
@@ -25,7 +25,6 @@ from q2_fondue.entrezpy_clients._pipelines import _get_run_ids
 
 threading.excepthook = handle_threaded_exception
 BATCH_SIZE = 150
-RUN_RETMAX = 10000  # todo: set even higher: > 40'000
 
 
 def _chunker(seq, size):
@@ -129,8 +128,7 @@ def _get_other_meta(
         email, n_jobs, project_ids, id_type, log_level, logger
 ) -> (pd.DataFrame, dict):
     run_ids = _get_run_ids(
-                    email, n_jobs, RUN_RETMAX, project_ids,
-                    id_type, log_level)
+                    email, n_jobs, project_ids, id_type, log_level)
 
     return _get_run_meta(email, n_jobs, run_ids, log_level, logger)
 

--- a/q2_fondue/metadata.py
+++ b/q2_fondue/metadata.py
@@ -128,9 +128,12 @@ def get_metadata(
     """Fetches metadata using the provided run/bioproject/study/sample or
     experiment accession IDs.
 
-    The IDs will be first validated using an ESearch query. The metadata
-    will be fetched only if all the IDs are valid. Otherwise, the user
-    will be informed on which IDs require checking.
+    If aggregate IDs (such as bioproject, study, sample, experiment IDs) were
+    provided, first run IDs will be fetched using a Conduit Pipeline.
+    The run IDs will be validated using an ESearch query. The metadata will
+    be fetched only for the valid run IDs. Invalid run IDs will be raised
+    with a warning. Run IDs for which the metadata could not be fetched will
+    be returned with the corresponding error message as missing_ids.
 
     Args:
         accession_ids (Metadata): List of all the accession IDs

--- a/q2_fondue/metadata.py
+++ b/q2_fondue/metadata.py
@@ -20,7 +20,7 @@ from q2_fondue.utils import (
 )
 from q2_fondue.entrezpy_clients._utils import (set_up_entrezpy_logging,
                                                set_up_logger, InvalidIDs)
-from q2_fondue.entrezpy_clients._pipelines import _get_run_ids
+from q2_fondue.entrezpy_clients._pipelines import _get_run_ids, RUN_RETMAX
 
 
 threading.excepthook = handle_threaded_exception
@@ -127,7 +127,19 @@ def _get_run_meta(
 def _get_other_meta(
         email, n_jobs, project_ids, id_type, log_level, logger
 ) -> (pd.DataFrame, dict):
-    run_ids = _get_run_ids(email, n_jobs, project_ids, id_type, log_level)
+    i = 0
+    run_ids = []
+    more_needed = True
+
+    while more_needed:
+        batch_run_ids = _get_run_ids(
+                    email, n_jobs, i, project_ids, id_type, log_level)
+        i += 1
+        run_ids += batch_run_ids
+        # if batch_run_ids==RUN_RETMAX, there might be more run IDs to fetch
+        if len(batch_run_ids) != RUN_RETMAX:
+            more_needed = False
+
     return _get_run_meta(email, n_jobs, run_ids, log_level, logger)
 
 

--- a/q2_fondue/metadata.py
+++ b/q2_fondue/metadata.py
@@ -57,8 +57,6 @@ def _efetcher_inquire(
 
     if metadata_response.result is None:
         error_msg = metadata_response.error_msg
-        if error_msg == '':
-            error_msg = 'NCBI did not return this ID. Try again.'
         return (pd.DataFrame(),
                 {m_id: error_msg for m_id in run_ids})
     else:

--- a/q2_fondue/metadata.py
+++ b/q2_fondue/metadata.py
@@ -20,11 +20,12 @@ from q2_fondue.utils import (
 )
 from q2_fondue.entrezpy_clients._utils import (set_up_entrezpy_logging,
                                                set_up_logger, InvalidIDs)
-from q2_fondue.entrezpy_clients._pipelines import _get_run_ids, RUN_RETMAX
+from q2_fondue.entrezpy_clients._pipelines import _get_run_ids
 
 
 threading.excepthook = handle_threaded_exception
 BATCH_SIZE = 150
+RUN_RETMAX = 1000
 
 
 def _chunker(seq, size):
@@ -133,7 +134,8 @@ def _get_other_meta(
 
     while more_needed:
         batch_run_ids = _get_run_ids(
-                    email, n_jobs, i, project_ids, id_type, log_level)
+                    email, n_jobs, RUN_RETMAX, i, project_ids,
+                    id_type, log_level)
         i += 1
         run_ids += batch_run_ids
         # if batch_run_ids==RUN_RETMAX, there might be more run IDs to fetch

--- a/q2_fondue/tests/_utils.py
+++ b/q2_fondue/tests/_utils.py
@@ -26,7 +26,7 @@ from q2_fondue.entrezpy_clients._sra_meta import (SRAStudy, SRASample,
 
 class FakeParams:
     def __init__(self, temp_dir, uids=None, term=None, eutil='efetch.cgi',
-                 rettype='xml', retmode='text'):
+                 rettype='xml', retmode='xml'):
         self.query_id = 'some-id-123'
         self.term = term
         self.usehistory = False

--- a/q2_fondue/tests/data/efetch_b1_response_runs.xml
+++ b/q2_fondue/tests/data/efetch_b1_response_runs.xml
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="UTF-8"  ?>
+<!DOCTYPE eSummaryResult PUBLIC "-//NLM//DTD esummary v1 20041029//EN"
+        "https://eutils.ncbi.nlm.nih.gov/eutils/dtd/20041029/esummary-v1.dtd">
+<eSummaryResult>
+
+    <DocSum>
+        <Id>4</Id>
+        <Item Name="ExpXml" Type="String">&lt;Summary&gt;&lt;Title&gt;454
+            sequencing of Human HapMap individual NA18505 genomic paired-end
+            library&lt;/Title&gt;&lt;Platform instrument_model="454 GS FLX"&gt;LS454&lt;/Platform&gt;&lt;Statistics
+            total_runs="10" total_spots="4703662" total_bases="1306798474"
+            total_size="3205056622" load_done="true"
+            static_data_available="true" cluster_name="public"/&gt;&lt;/Summary&gt;&lt;Submitter
+            acc="SRA000197" center_name="454MSC" contact_name="Chris OSullivan"
+            lab_name=""/&gt;&lt;Experiment acc="SRX000003" ver="10"
+            status="public" name="454 sequencing of Human HapMap individual
+            NA18505 genomic paired-end library"/&gt;&lt;Study acc="SRP000001"
+            name="Paired-end mapping reveals extensive structural variation in
+            the human genome"/&gt;&lt;Organism taxid="9606"
+            ScientificName="Homo sapiens"/&gt;&lt;Sample acc="SRS000100"
+            name=""/&gt;&lt;Instrument LS454="454 GS FLX"/&gt;&lt;Library_descriptor&gt;&lt;LIBRARY_NAME
+            xmlns=""&gt;SID2699&lt;/LIBRARY_NAME&gt;&lt;LIBRARY_STRATEGY
+            xmlns=""&gt;WGS&lt;/LIBRARY_STRATEGY&gt;&lt;LIBRARY_SOURCE xmlns=""&gt;GENOMIC&lt;/LIBRARY_SOURCE&gt;&lt;LIBRARY_SELECTION
+            xmlns=""&gt;RANDOM&lt;/LIBRARY_SELECTION&gt;&lt;LIBRARY_LAYOUT
+            xmlns=""&gt; &lt;PAIRED NOMINAL_LENGTH="3000"/&gt; &lt;/LIBRARY_LAYOUT&gt;&lt;/Library_descriptor&gt;&lt;Bioproject&gt;PRJNA33627&lt;/Bioproject&gt;&lt;Biosample&gt;SAMN00001583&lt;/Biosample&gt;
+        </Item>
+        <Item Name="Runs" Type="String">&lt;Run acc="SRR000007"
+            total_spots="633196" total_bases="175275395" load_done="true"
+            is_public="true" cluster_name="public"
+            static_data_available="true"/&gt;&lt;Run acc="SRR000018"
+            total_spots="626624" total_bases="174403220" load_done="true"
+            is_public="true" cluster_name="public"
+            static_data_available="true"/&gt;&lt;Run acc="SRR000020"
+            total_spots="374556" total_bases="103411232" load_done="true"
+            is_public="true" cluster_name="public"
+            static_data_available="true"/&gt;&lt;Run acc="SRR000038"
+            total_spots="529820" total_bases="148389031" load_done="true"
+            is_public="true" cluster_name="public"
+            static_data_available="true"/&gt;&lt;Run acc="SRR000043"
+            total_spots="608946" total_bases="168985392" load_done="true"
+            is_public="true" cluster_name="public"
+            static_data_available="true"/&gt;&lt;Run acc="SRR000046"
+            total_spots="79047" total_bases="21258857" load_done="true"
+            is_public="true" cluster_name="public"
+            static_data_available="true"/&gt;&lt;Run acc="SRR000048"
+            total_spots="640737" total_bases="177619279" load_done="true"
+            is_public="true" cluster_name="public"
+            static_data_available="true"/&gt;&lt;Run acc="SRR000050"
+            total_spots="547349" total_bases="153260655" load_done="true"
+            is_public="true" cluster_name="public"
+            static_data_available="true"/&gt;&lt;Run acc="SRR000057"
+            total_spots="76744" total_bases="21203932" load_done="true"
+            is_public="true" cluster_name="public"
+            static_data_available="true"/&gt;&lt;Run acc="SRR000058"
+            total_spots="586643" total_bases="162991481" load_done="true"
+            is_public="true" cluster_name="public"
+            static_data_available="true"/&gt;
+        </Item>
+        <Item Name="ExtLinks" Type="String"></Item>
+        <Item Name="CreateDate" Type="String">2008/04/04</Item>
+        <Item Name="UpdateDate" Type="String">2015/04/09</Item>
+    </DocSum>
+
+</eSummaryResult>

--- a/q2_fondue/tests/data/efetch_b2_response_runs.xml
+++ b/q2_fondue/tests/data/efetch_b2_response_runs.xml
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="UTF-8"  ?>
+<!DOCTYPE eSummaryResult PUBLIC "-//NLM//DTD esummary v1 20041029//EN"
+        "https://eutils.ncbi.nlm.nih.gov/eutils/dtd/20041029/esummary-v1.dtd">
+<eSummaryResult>
+
+    <DocSum>
+        <Id>13481774</Id>
+        <Item Name="ExpXml" Type="String">&lt;Summary&gt;&lt;Title&gt;18&lt;/Title&gt;&lt;Platform
+            instrument_model="Illumina HiSeq 3000"&gt;ILLUMINA&lt;/Platform&gt;&lt;Statistics
+            total_runs="1" total_spots="63703" total_bases="38349206"
+            total_size="22735317" load_done="true" cluster_name="public"/&gt;&lt;/Summary&gt;&lt;Submitter
+            acc="SRA1206349" center_name="Jiangxi Agricultural University"
+            contact_name="huan chen" lab_name="Jiangxi Province Key Laboratory
+            of Animal Nutritio"/&gt;&lt;Experiment acc="SRX10339760" ver="1"
+            status="public" name="18"/&gt;&lt;Study acc="SRP310597" name="PRJNA
+            Chuanzhong black lamb Raw sequence reads"/&gt;&lt;Organism
+            taxid="1904483" ScientificName="sheep gut metagenome"/&gt;&lt;Sample
+            acc="SRS8459117" name=""/&gt;&lt;Instrument ILLUMINA="Illumina
+            HiSeq 3000"/&gt;&lt;Library_descriptor&gt;&lt;LIBRARY_NAME&gt;18&lt;/LIBRARY_NAME&gt;&lt;LIBRARY_STRATEGY&gt;AMPLICON&lt;/LIBRARY_STRATEGY&gt;&lt;LIBRARY_SOURCE&gt;GENOMIC&lt;/LIBRARY_SOURCE&gt;&lt;LIBRARY_SELECTION&gt;PCR&lt;/LIBRARY_SELECTION&gt;&lt;LIBRARY_LAYOUT&gt;
+            &lt;PAIRED/&gt; &lt;/LIBRARY_LAYOUT&gt;&lt;/Library_descriptor&gt;&lt;Bioproject&gt;PRJNA707607&lt;/Bioproject&gt;&lt;Biosample&gt;SAMN18309312&lt;/Biosample&gt;
+        </Item>
+        <Item Name="Runs" Type="String">&lt;Run acc="SRR13961771"
+            total_spots="63703" total_bases="38349206" load_done="true"
+            is_public="true" cluster_name="public"
+            static_data_available="true"/&gt;
+        </Item>
+        <Item Name="ExtLinks" Type="String"></Item>
+        <Item Name="CreateDate" Type="String">2021/03/17</Item>
+        <Item Name="UpdateDate" Type="String">2021/03/15</Item>
+    </DocSum>
+
+    <DocSum>
+        <Id>13481786</Id>
+        <Item Name="ExpXml" Type="String">&lt;Summary&gt;&lt;Title&gt;12&lt;/Title&gt;&lt;Platform
+            instrument_model="Illumina HiSeq 3000"&gt;ILLUMINA&lt;/Platform&gt;&lt;Statistics
+            total_runs="1" total_spots="59130" total_bases="35596260"
+            total_size="21079845" load_done="true" cluster_name="public"/&gt;&lt;/Summary&gt;&lt;Submitter
+            acc="SRA1206349" center_name="Jiangxi Agricultural University"
+            contact_name="huan chen" lab_name="Jiangxi Province Key Laboratory
+            of Animal Nutritio"/&gt;&lt;Experiment acc="SRX10339772" ver="1"
+            status="public" name="12"/&gt;&lt;Study acc="SRP310597" name="PRJNA
+            Chuanzhong black lamb Raw sequence reads"/&gt;&lt;Organism
+            taxid="1904483" ScientificName="sheep gut metagenome"/&gt;&lt;Sample
+            acc="SRS8459130" name=""/&gt;&lt;Instrument ILLUMINA="Illumina
+            HiSeq 3000"/&gt;&lt;Library_descriptor&gt;&lt;LIBRARY_NAME&gt;12&lt;/LIBRARY_NAME&gt;&lt;LIBRARY_STRATEGY&gt;AMPLICON&lt;/LIBRARY_STRATEGY&gt;&lt;LIBRARY_SOURCE&gt;GENOMIC&lt;/LIBRARY_SOURCE&gt;&lt;LIBRARY_SELECTION&gt;PCR&lt;/LIBRARY_SELECTION&gt;&lt;LIBRARY_LAYOUT&gt;
+            &lt;PAIRED/&gt; &lt;/LIBRARY_LAYOUT&gt;&lt;/Library_descriptor&gt;&lt;Bioproject&gt;PRJNA707607&lt;/Bioproject&gt;&lt;Biosample&gt;SAMN18309306&lt;/Biosample&gt;
+        </Item>
+        <Item Name="Runs" Type="String">&lt;Run acc="SRR13961759"
+            total_spots="59130" total_bases="35596260" load_done="true"
+            is_public="true" cluster_name="public"
+            static_data_available="true"/&gt;
+        </Item>
+        <Item Name="ExtLinks" Type="String"></Item>
+        <Item Name="CreateDate" Type="String">2021/03/17</Item>
+        <Item Name="UpdateDate" Type="String">2021/03/15</Item>
+    </DocSum>
+</eSummaryResult>

--- a/q2_fondue/tests/data/metadata_response_error.xml
+++ b/q2_fondue/tests/data/metadata_response_error.xml
@@ -1,0 +1,3 @@
+<?xml version="1.0"  ?>
+<ERROR>
+</ERROR>

--- a/q2_fondue/tests/test_efetch.py
+++ b/q2_fondue/tests/test_efetch.py
@@ -210,7 +210,6 @@ class TestEfetchClients(_TestPluginWithEntrezFakeComponents):
                              ['FAKEID1'])
         self.assertEqual(1, self.efetch_result_single.size())
         self.assertFalse(self.efetch_result_single.isEmpty())
-        self.assertEqual(self.efetch_result_single.error_msg, None)
 
     def test_efetch_add_metadata_one_experiment_many_runs(self):
         self.efetch_result_single.add_metadata(
@@ -220,7 +219,6 @@ class TestEfetchClients(_TestPluginWithEntrezFakeComponents):
                              ['FAKEID1', 'FAKEID3'])
         self.assertEqual(2, self.efetch_result_single.size())
         self.assertFalse(self.efetch_result_single.isEmpty())
-        self.assertEqual(self.efetch_result_single.error_msg, None)
 
     def test_efetch_add_metadata_many_experiments_one_run(self):
         self.efetch_result_single.add_metadata(
@@ -230,7 +228,6 @@ class TestEfetchClients(_TestPluginWithEntrezFakeComponents):
                              ['FAKEID1'])
         self.assertEqual(1, self.efetch_result_single.size())
         self.assertFalse(self.efetch_result_single.isEmpty())
-        self.assertEqual(self.efetch_result_single.error_msg, None)
 
     def test_efetch_add_metadata_many_experiments_many_runs(self):
         self.efetch_result_single.add_metadata(
@@ -240,7 +237,6 @@ class TestEfetchClients(_TestPluginWithEntrezFakeComponents):
                              ['FAKEID1', 'FAKEID2'])
         self.assertEqual(2, self.efetch_result_single.size())
         self.assertFalse(self.efetch_result_single.isEmpty())
-        self.assertEqual(self.efetch_result_single.error_msg, None)
 
     def test_efetch_to_df(self):
         self.efetch_result_single.add_metadata(

--- a/q2_fondue/tests/test_efetch.py
+++ b/q2_fondue/tests/test_efetch.py
@@ -210,6 +210,7 @@ class TestEfetchClients(_TestPluginWithEntrezFakeComponents):
                              {0: ['FAKEID1']})
         self.assertEqual(1, self.efetch_result_single.size())
         self.assertFalse(self.efetch_result_single.isEmpty())
+        self.assertEqual(self.efetch_result_single.error_msg, None)
 
     def test_efetch_add_metadata_one_experiment_many_runs(self):
         self.efetch_result_single.add_metadata(
@@ -219,6 +220,7 @@ class TestEfetchClients(_TestPluginWithEntrezFakeComponents):
                              {0: ['FAKEID1'], 1: ['FAKEID3']})
         self.assertEqual(2, self.efetch_result_single.size())
         self.assertFalse(self.efetch_result_single.isEmpty())
+        self.assertEqual(self.efetch_result_single.error_msg, None)
 
     def test_efetch_add_metadata_many_experiments_one_run(self):
         self.efetch_result_single.add_metadata(
@@ -228,6 +230,7 @@ class TestEfetchClients(_TestPluginWithEntrezFakeComponents):
                              {0: ['FAKEID1']})
         self.assertEqual(1, self.efetch_result_single.size())
         self.assertFalse(self.efetch_result_single.isEmpty())
+        self.assertEqual(self.efetch_result_single.error_msg, None)
 
     def test_efetch_add_metadata_many_experiments_many_runs(self):
         self.efetch_result_single.add_metadata(
@@ -237,18 +240,7 @@ class TestEfetchClients(_TestPluginWithEntrezFakeComponents):
                              {0: ['FAKEID1'], 1: ['FAKEID2']})
         self.assertEqual(2, self.efetch_result_single.size())
         self.assertFalse(self.efetch_result_single.isEmpty())
-
-    def test_efetch_add_metadata_many_experiments_many_runs_missing_ids(self):
-        self.efetch_result_single.add_metadata(
-            self.xml_to_response('single'), ['FAKEID1', 'FAKEID2']
-        )
-
-        self.assertDictEqual(self.efetch_result_single.metadata,
-                             {0: ['FAKEID1']})
-        self.assertEqual(1, self.efetch_result_single.size())
-        self.assertFalse(self.efetch_result_single.isEmpty())
-        self.assertListEqual(['FAKEID2'],
-                             self.efetch_result_single.missing_uids)
+        self.assertEqual(self.efetch_result_single.error_msg, None)
 
     def test_efetch_to_df(self):
         self.efetch_result_single.add_metadata(

--- a/q2_fondue/tests/test_efetch.py
+++ b/q2_fondue/tests/test_efetch.py
@@ -305,6 +305,21 @@ class TestEfetchClients(_TestPluginWithEntrezFakeComponents):
         exp = ['FAKEID1']
         self.assertListEqual(exp, self.efetch_analyzer.result.metadata)
 
+    def test_efanalyzer_analyze_error(self):
+        raw_response = self.xml_to_response('error')
+        request = self.generate_ef_request(['FAKEID1'])
+        response = self.efetch_analyzer.convert_response(
+            raw_response.read().decode('utf-8'), request)
+
+        self.efetch_analyzer.analyze_error(
+            response=response, request=request
+        )
+
+        self.assertEqual(
+            self.efetch_analyzer.error_msg,
+            '<?xml version="1.0"  ?>\n<ERROR>\n</ERROR>\n'
+            )
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/q2_fondue/tests/test_efetch.py
+++ b/q2_fondue/tests/test_efetch.py
@@ -8,7 +8,7 @@
 
 import pandas as pd
 import unittest
-from pandas._testing import assert_frame_equal, assert_series_equal
+from pandas._testing import assert_frame_equal
 from unittest.mock import MagicMock
 
 from q2_fondue.entrezpy_clients._efetch import EFetchResult
@@ -206,8 +206,8 @@ class TestEfetchClients(_TestPluginWithEntrezFakeComponents):
         self.efetch_result_single.add_metadata(
             self.xml_to_response('single'), ['FAKEID1']
         )
-        self.assertDictEqual(self.efetch_result_single.metadata,
-                             {0: ['FAKEID1']})
+        self.assertListEqual(self.efetch_result_single.metadata,
+                             ['FAKEID1'])
         self.assertEqual(1, self.efetch_result_single.size())
         self.assertFalse(self.efetch_result_single.isEmpty())
         self.assertEqual(self.efetch_result_single.error_msg, None)
@@ -216,8 +216,8 @@ class TestEfetchClients(_TestPluginWithEntrezFakeComponents):
         self.efetch_result_single.add_metadata(
             self.xml_to_response('single', '_complex'), ['FAKEID1', 'FAKEID3']
         )
-        self.assertDictEqual(self.efetch_result_single.metadata,
-                             {0: ['FAKEID1'], 1: ['FAKEID3']})
+        self.assertListEqual(self.efetch_result_single.metadata,
+                             ['FAKEID1', 'FAKEID3'])
         self.assertEqual(2, self.efetch_result_single.size())
         self.assertFalse(self.efetch_result_single.isEmpty())
         self.assertEqual(self.efetch_result_single.error_msg, None)
@@ -226,8 +226,8 @@ class TestEfetchClients(_TestPluginWithEntrezFakeComponents):
         self.efetch_result_single.add_metadata(
             self.xml_to_response('multi'), ['FAKEID1']
         )
-        self.assertDictEqual(self.efetch_result_single.metadata,
-                             {0: ['FAKEID1']})
+        self.assertListEqual(self.efetch_result_single.metadata,
+                             ['FAKEID1'])
         self.assertEqual(1, self.efetch_result_single.size())
         self.assertFalse(self.efetch_result_single.isEmpty())
         self.assertEqual(self.efetch_result_single.error_msg, None)
@@ -236,8 +236,8 @@ class TestEfetchClients(_TestPluginWithEntrezFakeComponents):
         self.efetch_result_single.add_metadata(
             self.xml_to_response('multi'), ['FAKEID1', 'FAKEID2']
         )
-        self.assertDictEqual(self.efetch_result_single.metadata,
-                             {0: ['FAKEID1'], 1: ['FAKEID2']})
+        self.assertListEqual(self.efetch_result_single.metadata,
+                             ['FAKEID1', 'FAKEID2'])
         self.assertEqual(2, self.efetch_result_single.size())
         self.assertFalse(self.efetch_result_single.isEmpty())
         self.assertEqual(self.efetch_result_single.error_msg, None)
@@ -279,37 +279,25 @@ class TestEfetchClients(_TestPluginWithEntrezFakeComponents):
     def test_efetch_extract_run_ids(self):
         self.efetch_result_single.extract_run_ids(
             self.xml_to_response('runs', prefix='efetch'))
-        exp_ids = {
-            0: ['SRR13961771'],
-            1: ['SRR000007', 'SRR000018', 'SRR000020', 'SRR000038',
-                'SRR000043', 'SRR000046', 'SRR000048', 'SRR000050',
-                'SRR000057', 'SRR000058'],
-            2: ['SRR13961759']
-        }
-        self.assertDictEqual(exp_ids, self.efetch_result_single.metadata)
+        exp_ids = [
+            'SRR13961771', 'SRR000007', 'SRR000018', 'SRR000020',
+            'SRR000038', 'SRR000043', 'SRR000046', 'SRR000048',
+            'SRR000050', 'SRR000057', 'SRR000058', 'SRR13961759']
+
+        self.assertListEqual(
+            sorted(exp_ids), sorted(self.efetch_result_single.metadata))
 
     def test_efetch_extract_run_ids_single_element(self):
         response = self.xml_to_response(
             'runs', prefix='efetch', suffix='_single_item'
         )
         self.efetch_result_single.extract_run_ids(response)
-        exp_ids = {
-            0: ['SRR000007', 'SRR000018', 'SRR000020', 'SRR000038',
-                'SRR000043', 'SRR000046', 'SRR000048', 'SRR000050',
-                'SRR000057', 'SRR000058']
-        }
-        self.assertDictEqual(exp_ids, self.efetch_result_single.metadata)
-
-    def test_efetch_metadata_to_series(self):
-        self.efetch_result_single.extract_run_ids(
-            self.xml_to_response('runs', prefix='efetch'))
-
-        obs_ids = self.efetch_result_single.metadata_to_series()
-        exp_ids = pd.Series([
-            'SRR13961771', 'SRR000007', 'SRR000018', 'SRR000020',
-            'SRR000038', 'SRR000043', 'SRR000046', 'SRR000048', 'SRR000050',
-            'SRR000057', 'SRR000058', 'SRR13961759'], index=range(12))
-        assert_series_equal(exp_ids, obs_ids)
+        exp_ids = [
+            'SRR000007', 'SRR000018', 'SRR000020', 'SRR000038',
+            'SRR000043', 'SRR000046', 'SRR000048', 'SRR000050',
+            'SRR000057', 'SRR000058']
+        self.assertListEqual(
+            sorted(exp_ids), sorted(self.efetch_result_single.metadata))
 
     def test_efanalyzer_analyze_result(self):
         self.efetch_analyzer.analyze_result(
@@ -318,8 +306,8 @@ class TestEfetchClients(_TestPluginWithEntrezFakeComponents):
         )
 
         self.assertTrue(isinstance(self.efetch_analyzer.result, EFetchResult))
-        exp = {0: ['FAKEID1']}
-        self.assertDictEqual(exp, self.efetch_analyzer.result.metadata)
+        exp = ['FAKEID1']
+        self.assertListEqual(exp, self.efetch_analyzer.result.metadata)
 
 
 if __name__ == "__main__":

--- a/q2_fondue/tests/test_get_all.py
+++ b/q2_fondue/tests/test_get_all.py
@@ -25,7 +25,6 @@ from q2_fondue.tests.test_sequences import SequenceTests
 class TestGetAll(SequenceTests):
     package = 'q2_fondue.tests'
 
-    @patch('q2_fondue.metadata.es.Esearcher')
     @patch('q2_fondue.metadata._validate_esearch_result')
     @patch('q2_fondue.metadata.ef.Efetcher')
     @patch('q2_fondue.metadata._efetcher_inquire')
@@ -38,7 +37,7 @@ class TestGetAll(SequenceTests):
     def test_get_all_single(
             self, mock_tmpdir, mock_casava, mock_announce, mock_pool,
             mock_proc, mock_sleep, mock_inquire, mock_efetcher,
-            mock_validation, mock_esearcher
+            mock_validation
     ):
         """
         Test verifying that pipeline get_all calls all expected actions,
@@ -79,10 +78,8 @@ class TestGetAll(SequenceTests):
         fondue.actions.get_all(test_md, 'fake@email.com', retries=1)
 
         # function call assertions for get_metadata within
-        mock_esearcher.assert_called_once_with(
-            'esearcher', 'fake@email.com', apikey=None, apikey_var=None,
-            threads=1, qid=None)
-        mock_validation.assert_called_once_with(ANY, [acc_id], 'INFO')
+        mock_validation.assert_called_once_with(
+            'fake@email.com', 1, [acc_id], 'INFO')
         mock_efetcher.assert_called_once_with(
             'efetcher', 'fake@email.com', apikey=None, apikey_var=None,
             threads=1, qid=None)
@@ -102,7 +99,6 @@ class TestGetAll(SequenceTests):
         )
 
     @patch('q2_fondue.metadata.BATCH_SIZE', 1)
-    @patch('q2_fondue.metadata.es.Esearcher')
     @patch('q2_fondue.metadata._validate_esearch_result')
     @patch('q2_fondue.metadata.ef.Efetcher')
     @patch('q2_fondue.metadata._efetcher_inquire')
@@ -115,7 +111,7 @@ class TestGetAll(SequenceTests):
     def test_get_all_multi_with_missing_ids(
             self, mock_tmpdir, mock_casava, mock_announce, mock_pool,
             mock_proc, mock_sleep, mock_inquire, mock_efetcher,
-            mock_validation, mock_esearcher
+            mock_validation
     ):
         """
         Test verifying that pipeline get_all calls all expected actions,
@@ -168,10 +164,8 @@ class TestGetAll(SequenceTests):
             missing_ids_exp)
 
         # function call assertions for get_metadata within
-        mock_esearcher.assert_called_once_with(
-            'esearcher', 'fake@email.com', apikey=None, apikey_var=None,
-            threads=1, qid=None)
-        mock_validation.assert_called_once_with(ANY, acc_ids, 'INFO')
+        mock_validation.assert_called_once_with(
+            'fake@email.com', 1, acc_ids, 'INFO')
         mock_efetcher.assert_called_with(
             'efetcher', 'fake@email.com', apikey=None, apikey_var=None,
             threads=1, qid=None)

--- a/q2_fondue/tests/test_get_all.py
+++ b/q2_fondue/tests/test_get_all.py
@@ -25,7 +25,7 @@ from q2_fondue.tests.test_sequences import SequenceTests
 class TestGetAll(SequenceTests):
     package = 'q2_fondue.tests'
 
-    @patch('q2_fondue.metadata._validate_esearch_result')
+    @patch('q2_fondue.metadata._validate_run_ids')
     @patch('q2_fondue.metadata.ef.Efetcher')
     @patch('q2_fondue.metadata._efetcher_inquire')
     @patch('time.sleep')
@@ -99,7 +99,7 @@ class TestGetAll(SequenceTests):
         )
 
     @patch('q2_fondue.metadata.BATCH_SIZE', 1)
-    @patch('q2_fondue.metadata._validate_esearch_result')
+    @patch('q2_fondue.metadata._validate_run_ids')
     @patch('q2_fondue.metadata.ef.Efetcher')
     @patch('q2_fondue.metadata._efetcher_inquire')
     @patch('time.sleep')

--- a/q2_fondue/tests/test_get_all.py
+++ b/q2_fondue/tests/test_get_all.py
@@ -53,7 +53,7 @@ class TestGetAll(SequenceTests):
 
         path2df = self.get_data_path('sra-metadata-mock.tsv')
         mock_inquire.return_value = (
-            pd.read_csv(path2df, sep='\t', index_col=0), []
+            pd.read_csv(path2df, sep='\t', index_col=0), {}
         )
 
         # define mocked return values for get_sequences mocks
@@ -129,7 +129,7 @@ class TestGetAll(SequenceTests):
 
         path2df = self.get_data_path('sra-metadata-mock.tsv')
         mock_inquire.return_value = (
-            pd.read_csv(path2df, sep='\t', index_col=0), []
+            pd.read_csv(path2df, sep='\t', index_col=0), {}
         )
 
         # define mocked return values for get_sequences mocks

--- a/q2_fondue/tests/test_metadata.py
+++ b/q2_fondue/tests/test_metadata.py
@@ -68,12 +68,6 @@ class TestMetadataFetching(_TestPluginWithEntrezFakeComponents):
         self.fake_econduit = FakeConduit(
             self.generate_ef_result(kind='runs', prefix='efetch'),
             self.xml_to_response('runs', prefix='efetch'))
-        self.fake_econduit_b1 = FakeConduit(
-            self.generate_ef_result(kind='runs', prefix='efetch_b1'),
-            self.xml_to_response('runs', prefix='efetch_b1'))
-        self.fake_econduit_b2 = FakeConduit(
-            self.generate_ef_result(kind='runs', prefix='efetch_b2'),
-            self.xml_to_response('runs', prefix='efetch_b2'))
 
     def generate_meta_df(self, obs_suffices, exp_suffix):
         meta_dfs = []
@@ -346,63 +340,37 @@ class TestMetadataFetching(_TestPluginWithEntrezFakeComponents):
                 cm.output
             )
 
-    @parameterized.expand([
-        ("study", "sra"),
-        ("bioproject", "bioproject"),
-        ("experiment", "sra"),
-        ("sample", "sra")
-        ])
+    # @parameterized.expand([
+    #     ("study", "sra"),
+    #     ("bioproject", "bioproject"),
+    #     ("experiment", "sra"),
+    #     ("sample", "sra")
+    #     ])
     @patch('q2_fondue.metadata._get_run_meta')
-    def test_get_other_meta(self, id_type, db2search, patched_get):
+    def test_get_other_meta_dirty(self, patched_get):
+        # todo: proper testing of functionality with
+        # todo: esearch_result mocking (probably with):
+        # from q2_fondue.entrezpy_clients._esearch import ESearchAnalyzer
+        # patched_es_iq.return_value =
+        #   self.generate_es_result('multi', '_correct')
+        # todo: parameterize again
+        id_type = "bioproject"
+        db2search = "bioproject"
+        exp_ids = [
+            'SRR000007', 'SRR000018', 'SRR000020', 'SRR000038',
+            'SRR000043', 'SRR000046', 'SRR000048', 'SRR000050',
+            'SRR000057', 'SRR000058', 'SRR13961759', 'SRR13961771']
         with patch.object(conduit, 'Conduit') as mock_conduit:
             mock_conduit.return_value = self.fake_econduit
+            patched_get.return_value = exp_ids
             _ = _get_other_meta(
                 'someone@somewhere.com', 1, ['AB', 'cd'], id_type,
                 'INFO', MagicMock()
             )
 
-            exp_ids = ['SRR13961771', 'SRR000007', 'SRR000018', 'SRR000020',
-                       'SRR000038', 'SRR000043', 'SRR000046', 'SRR000048',
-                       'SRR000050', 'SRR000057', 'SRR000058', 'SRR13961759']
-
             self.fake_econduit.pipeline.add_search.assert_called_once_with(
                 {'db': db2search, 'term': "AB OR cd"}, analyzer=ANY
             )
-            patched_get.assert_called_once_with(
-                'someone@somewhere.com', 1, exp_ids, 'INFO', ANY
-            )
-
-    @patch('q2_fondue.metadata.RUN_RETMAX', 10)
-    @patch('q2_fondue.metadata._get_run_meta')
-    def test_get_other_meta_batching(self, patched_get):
-        with patch.object(conduit, 'Conduit') as mock_conduit:
-            mock_conduit.side_effect = ([self.fake_econduit_b1,
-                                         self.fake_econduit_b2])
-            _ = _get_other_meta(
-                'someone@somewhere.com', 1, ['AB', 'cd'], 'bioproject',
-                'INFO', MagicMock()
-            )
-            # test first batch retrieval
-            self.fake_econduit_b1.pipeline.add_search.assert_called_once_with(
-                {'db': 'bioproject', 'term': "AB OR cd"}, analyzer=ANY
-            )
-            self.fake_econduit_b1.pipeline.add_fetch.assert_called_once_with(
-                {'rettype': 'docsum', 'retmode': 'xml',
-                    'retmax': 10, 'retstart': 0},
-                analyzer=ANY, dependency=ANY)
-            # test second batch retrieval
-            self.fake_econduit_b2.pipeline.add_search.assert_called_once_with(
-                {'db': 'bioproject', 'term': "AB OR cd"}, analyzer=ANY
-            )
-            self.fake_econduit_b2.pipeline.add_fetch.assert_called_once_with(
-                {'rettype': 'docsum', 'retmode': 'xml',
-                    'retmax': 10, 'retstart': 10},
-                analyzer=ANY, dependency=ANY)
-            # check that all run IDs were fetched
-            exp_ids = [
-                'SRR000007', 'SRR000018', 'SRR000020', 'SRR000038',
-                'SRR000043', 'SRR000046', 'SRR000048', 'SRR000050',
-                'SRR000057', 'SRR000058', 'SRR13961771', 'SRR13961759']
             patched_get.assert_called_once_with(
                 'someone@somewhere.com', 1, exp_ids, 'INFO', ANY
             )

--- a/q2_fondue/tests/test_metadata.py
+++ b/q2_fondue/tests/test_metadata.py
@@ -29,7 +29,7 @@ from q2_fondue.metadata import (
 )
 from q2_fondue.tests._utils import _TestPluginWithEntrezFakeComponents
 from q2_fondue.utils import (
-    _validate_esearch_result, _determine_id_type
+    _validate_run_ids, _determine_id_type
 )
 
 
@@ -183,7 +183,7 @@ class TestMetadataFetching(_TestPluginWithEntrezFakeComponents):
             mock_search.return_value = self.fake_esearcher
             mock_request.return_value = self.json_to_response(
                 'single', '_correct', True)
-            obs_result = _validate_esearch_result(
+            obs_result = _validate_run_ids(
                 'someone@somewhere.com', 1, ['SRR000001'], 'INFO'
             )
         obs_request, = mock_request.call_args.args
@@ -201,7 +201,7 @@ class TestMetadataFetching(_TestPluginWithEntrezFakeComponents):
             mock_search.return_value = self.fake_esearcher
             mock_request.return_value = self.json_to_response(
                 'multi', '_correct', True)
-            obs_result = _validate_esearch_result(
+            obs_result = _validate_run_ids(
                 'someone@somewhere.com', 1,
                 ['SRR000001', 'SRR000013', 'ERR3978173'],
                 'INFO'
@@ -218,14 +218,14 @@ class TestMetadataFetching(_TestPluginWithEntrezFakeComponents):
 
     @patch('entrezpy.esearch.esearcher.Esearcher')
     @patch.object(_esearch, 'ESearchAnalyzer')
-    def test_validate_esearch_result_one_batch(
+    def test_validate_run_ids_one_batch(
             self, mock_analyzer, mock_search):
         ids = ['SRR000001', 'SRR000013', 'ERR3978173']
         mock_analyzer.return_value = FakeAnalyzerValidation(
             ids, [1, 1, 1])
         mock_search.return_value.inquire = mock_analyzer
 
-        obs_invalid = _validate_esearch_result(
+        obs_invalid = _validate_run_ids(
             'someone@somewhere.com', 1, ids, 'INFO')
 
         self.assertEqual(
@@ -236,7 +236,7 @@ class TestMetadataFetching(_TestPluginWithEntrezFakeComponents):
     @patch('entrezpy.esearch.esearcher.Esearcher')
     @patch.object(_esearch, 'ESearchAnalyzer')
     @patch('q2_fondue.utils._chunker')
-    def test_validate_esearch_result_multiple_batches(
+    def test_validate_run_ids_multiple_batches(
             self, mock_chunker, mock_analyzer, mock_search):
         ids = ['SRR000001', 'SRR000013', 'ERR3978173']
         mock_chunker.return_value = (
@@ -249,7 +249,7 @@ class TestMetadataFetching(_TestPluginWithEntrezFakeComponents):
         mock_analyzer.side_effect = [first_analyzer, second_analyzer]
         mock_search.return_value.inquire = mock_analyzer
 
-        obs_invalid = _validate_esearch_result(
+        obs_invalid = _validate_run_ids(
             'someone@somewhere.com', 1, ids, 'INFO')
 
         self.assertEqual(
@@ -295,7 +295,7 @@ class TestMetadataFetching(_TestPluginWithEntrezFakeComponents):
         exp_map = {'ab12': 0, 'bc23': 0, 'cd34': 0, 'de45': 0, 'ef56': 1}
         self.assertDictEqual(exp_map, obs_map)
 
-    @patch('q2_fondue.metadata._validate_esearch_result', return_value={})
+    @patch('q2_fondue.metadata._validate_run_ids', return_value={})
     @patch('q2_fondue.metadata._execute_efetcher')
     def test_get_run_meta(self, patch_ef, patch_val):
         exp_df = pd.DataFrame(
@@ -316,7 +316,7 @@ class TestMetadataFetching(_TestPluginWithEntrezFakeComponents):
             self.fake_logger
         )
 
-    @patch('q2_fondue.metadata._validate_esearch_result', return_value={})
+    @patch('q2_fondue.metadata._validate_run_ids', return_value={})
     @patch('q2_fondue.metadata._execute_efetcher')
     def test_get_run_meta_missing_ids(self, patch_ef, patch_val):
         exp_meta = pd.DataFrame(
@@ -349,7 +349,7 @@ class TestMetadataFetching(_TestPluginWithEntrezFakeComponents):
             )
 
     @patch.object(esearcher, 'Esearcher')
-    @patch('q2_fondue.metadata._validate_esearch_result')
+    @patch('q2_fondue.metadata._validate_run_ids')
     @patch('q2_fondue.metadata._execute_efetcher')
     def test_get_run_meta_no_valid_ids(self, patch_ef, patch_val, patch_es):
         patch_val.return_value = {
@@ -365,7 +365,7 @@ class TestMetadataFetching(_TestPluginWithEntrezFakeComponents):
             )
 
     @patch.object(esearcher, 'Esearcher')
-    @patch('q2_fondue.metadata._validate_esearch_result')
+    @patch('q2_fondue.metadata._validate_run_ids')
     @patch('q2_fondue.metadata._execute_efetcher')
     def test_get_run_meta_one_invalid_id(self, patch_ef, patch_val, patch_es):
         patch_val.return_value = {

--- a/q2_fondue/tests/test_metadata.py
+++ b/q2_fondue/tests/test_metadata.py
@@ -372,7 +372,6 @@ class TestMetadataFetching(_TestPluginWithEntrezFakeComponents):
                 'someone@somewhere.com', 1, exp_ids, 'INFO', ANY
             )
 
-    @patch('q2_fondue.entrezpy_clients._pipelines.RUN_RETMAX', 10)
     @patch('q2_fondue.metadata.RUN_RETMAX', 10)
     @patch('q2_fondue.metadata._get_run_meta')
     def test_get_other_meta_batching(self, patched_get):

--- a/q2_fondue/tests/test_utils.py
+++ b/q2_fondue/tests/test_utils.py
@@ -17,7 +17,7 @@ from qiime2.plugin.testing import TestPluginBase
 from tqdm import tqdm
 
 from q2_fondue.utils import (handle_threaded_exception, _has_enough_space,
-                             _find_next_id)
+                             _find_next_id, _chunker)
 
 
 class TestExceptHooks(unittest.TestCase):
@@ -118,6 +118,18 @@ class TestSRAUtils(TestPluginBase):
         pbar = tqdm(['A', 'B', 'C'])
         obs = _find_next_id('C', pbar)
         self.assertIsNone(obs)
+
+    def test_chunker(self):
+        obs_out = _chunker(['A', 'B', 'C'], 2)
+        exp_out_1 = ['A', 'B']
+        exp_out_2 = ['C']
+        self.assertEqual(next(obs_out), exp_out_1)
+        self.assertEqual(next(obs_out), exp_out_2)
+
+    def test_chunker_no_chunks(self):
+        obs_out = _chunker(['A', 'B', 'C'], 4)
+        exp_out = ['A', 'B', 'C']
+        self.assertEqual(next(obs_out), exp_out)
 
 
 if __name__ == "__main__":

--- a/q2_fondue/utils.py
+++ b/q2_fondue/utils.py
@@ -30,7 +30,7 @@ def _chunker(seq, size):
     return (seq[pos:pos + size] for pos in range(0, len(seq), size))
 
 
-def _validate_esearch_result(
+def _validate_run_ids(
         email: str, n_jobs: int, run_ids: List[str], log_level: str) -> dict:
     """Validates provided accession IDs using ESearch.
 
@@ -87,10 +87,6 @@ def handle_threaded_exception(args):
     # silence threads exiting correctly
     elif issubclass(args.exc_type, SystemExit) and str(args.exc_value) == '0':
         return
-    # todo: remove or uncomment below
-    # # silence empty threads (happens when RETMAX >>> fetched run IDs)
-    # elif issubclass(args.exc_type, SystemExit) and str(args.exc_value) == '':
-    #     return
     else:
         msg += f'Caught {args.exc_type} with value "{args.exc_value}" ' \
                f'in thread {args.thread}'

--- a/q2_fondue/utils.py
+++ b/q2_fondue/utils.py
@@ -69,6 +69,10 @@ def handle_threaded_exception(args):
     # silence threads exiting correctly
     elif issubclass(args.exc_type, SystemExit) and str(args.exc_value) == '0':
         return
+    # todo: remove or uncomment below
+    # # silence empty threads (happens when RETMAX >>> fetched run IDs)
+    # elif issubclass(args.exc_type, SystemExit) and str(args.exc_value) == '':
+    #     return
     else:
         msg += f'Caught {args.exc_type} with value "{args.exc_value}" ' \
                f'in thread {args.thread}'


### PR DESCRIPTION
this PR closes #77 and closes #123.

For fetching run IDs from aggregate IDs (such as BioProject, Study ID) it:
* enables fetching all run IDs associated with one aggregate ID (previously a maximum of only 10'000 run IDs could be fetched).

For fetching metadata of run IDs it:
* ensures all metadata is fetched by setting `retmax` with looping over uniformly sized batches of run IDs 
* adds logging of the error message in case the metadata fetching of one batch fails.
* returns missing IDs in the output artifact `--o-failed-runs`.
* raises warning in case invalid run IDs are present. (Invalid run IDs are intentionally not appended to the missing run IDs output because the latter should be easily refetched with a subsequent fetch using the output artifact `--o-failed-runs` whereas the former requires adjustments by the user.)

Special shout-out to @misialq for some fun co-debugging sessions along the way 🥳 


## Testing
Fetch metadata using `get-metadata` for a BioProject ID (or other aggregate ID) with a known (preferably large) number of run IDs associated with it and verify that the expected count of run IDs was fetched. 

