### PR TITLE
FIX: correctly install sra-toolkit during conda build

### DIFF
--- a/ci/recipe/meta.yaml
+++ b/ci/recipe/meta.yaml
@@ -10,7 +10,9 @@ source:
   path: ../..
 
 build:
-  script: make install
+  script: | 
+    make VERBOSE=1
+    make install
 
 requirements:
   host:

--- a/install-sra-tools.sh
+++ b/install-sra-tools.sh
@@ -29,16 +29,21 @@ tar -xzf sratoolkit.tar.gz
 rm sratoolkit.tar.gz
 mv "sratoolkit.${TOOLKIT_VER}-${OS_VER}/" "sratoolkit/"
 
-echo "Installing SRA Tools in $CONDA_PREFIX..."
-if [[ ! -d "$CONDA_PREFIX/bin/" ]]; then
-  mkdir $CONDA_PREFIX/bin/
+if [[ "$PREFIX" == "" ]]; then
+  echo "Setting PREFIX=$CONDA_PREFIX"
+  PREFIX="$CONDA_PREFIX"
 fi
-find sratoolkit/bin/ -maxdepth 1 -type f -exec mv -f {} $CONDA_PREFIX/bin/ \;
-find sratoolkit/bin/ -maxdepth 1 -type l -exec mv -f {} $CONDA_PREFIX/bin/ \;
+
+echo "Installing SRA Tools in $PREFIX..."
+if [[ ! -d "$PREFIX/bin/" ]]; then
+  mkdir $PREFIX/bin/
+fi
+find sratoolkit/bin/ -maxdepth 1 -type f -exec mv -f {} $PREFIX/bin/ \;
+find sratoolkit/bin/ -maxdepth 1 -type l -exec mv -f {} $PREFIX/bin/ \;
 rm -r sratoolkit
 
 echo "Testing installation..."
-if [[ $(which prefetch) == "$CONDA_PREFIX/bin"* ]]; then
+if [[ $(which prefetch) == "$PREFIX/bin"* ]]; then
   echo "Success!"
 else
   echo "Installation failed."


### PR DESCRIPTION
Adjusts the sra-toolkit installation script to use the `PREFIX` env variable when available (i.e., during conda builds) or `CONDA_PREFIX` when installing in an existing, activated conda environment.

**Testing**: to test, one needs to build the conda package locally and then install the built package in a fresh environment (I did that, all worked). It will be much easier to test after merging, once the CI takes care of the build process :) 