### PR TITLE
FIX: Correctly scraping accessions with whitespace characters

### DIFF
--- a/q2_fondue/scraper.py
+++ b/q2_fondue/scraper.py
@@ -234,9 +234,10 @@ def _find_hyphen_sequence(
         list: List of accession IDs with hyphenated IDs included.
     """
     # source of hyphens: https://stackoverflow.com/a/48923796 with \u00ad added
-    hyphens = r'[\u002D\u058A\u05BE\u1400\u1806\u2010-\u2015\u2E17\u2E1A\
-    \u2E3A\u2E3B\u2E40\u301C\u3030\u30A0\uFE31\uFE32\uFE58\uFE63\uFF0D\
-    \u00AD]'
+    hyphens_1 = r'[\u002D\u058A\u05BE\u1400\u1806\u2010-\u2015\u2E17\u2E1A'
+    hyphens_2 = r'\u2E3A\u2E3B\u2E40\u301C\u3030\u30A0\uFE31\uFE32\uFE58\uFE63'
+    hyphens_3 = r'\uFF0D\u00AD]'
+    hyphens = hyphens_1 + hyphens_2 + hyphens_3
     pattern_hyphen = pattern + r'\s*' + hyphens + r'\s*' + after_hyphen
     ids = []
     matches = re.findall(f'({pattern_hyphen})', txt)
@@ -285,12 +286,13 @@ def _find_accession_ids(txt: str, id_type: str) -> list:
     Returns:
         list: List of run, study, BioProject, experiment or sample IDs found.
     """
-    # DEFAULT: Find plain accession ID: PREFIX12345 or PREFIX 12345
+    # DEFAULT: Find plain accession ID:
+    # PREFIX12345 or PREFIX 12345 or PREFIX1 2345 (and variants thereof)
     patterns = {
-        'run': r'[EDS]RR\s?\d+', 'study': r'[EDS]RP\s?\d+',
-        'bioproject': r'PRJ[EDN][A-Z]\s?\d+',
-        'experiment': r'[EDS]RX\s?\d+',
-        'sample': r'[EDS]RS\s?\d+',
+        'run': r'[EDS]RR\s?\d+\s?\d+', 'study': r'[EDS]RP\s?\d+\s?\d+',
+        'bioproject': r'PRJ[EDN][A-Z]\s?\d+\s?\d+',
+        'experiment': r'[EDS]RX\s?\d+\s?\d+',
+        'sample': r'[EDS]RS\s?\d+\s?\d+',
     }
     pattern = patterns[id_type]
 

--- a/q2_fondue/tests/test_scraper.py
+++ b/q2_fondue/tests/test_scraper.py
@@ -207,6 +207,21 @@ class TestUtils4CollectionScraping(TestPluginBase):
         obs_run = _find_accession_ids(txt_w_2ids, 'run')
         self.assertListEqual(exp_run, obs_run)
 
+    @parameterized.expand([
+        "SRP1 32205",
+        "SRP13 2205",
+        "SRP132 205",
+        "SRP1322 05",
+        "SRP13220 5"
+        ])
+    def test_find_accession_ids_random_empty_space(self, txt_id):
+        # example inspired by this publication:
+        # https://doi.org/10.3389/fmicb.2018.02755
+        txt = f'sra.cgi?study = {txt_id}'
+        exp_out = ['SRP132205']
+        obs_out = _find_accession_ids(txt, 'study')
+        self.assertListEqual(exp_out, obs_out)
+
     def test_find_accession_ids_special_cases_one_comma(self):
         # example inspired by this publication:
         # https://doi.org/10.1038/s41467-021-26215-w
@@ -287,6 +302,16 @@ class TestUtils4CollectionScraping(TestPluginBase):
                     'PRJEB1479101', 'PRJEB1479102']
         obs_proj = _find_accession_ids(txt_diff, 'bioproject')
         self.assertListEqual(sorted(exp_proj), sorted(obs_proj))
+
+    def test_find_accession_ids_special_cases_no_hyphen(
+            self):
+        # example inspired by this publication:
+        # https://doi.org/10.1186/s40168-015-0089-2 where a former regex
+        # implementation mistakenly took this text as a hyphenated sequence
+        txt = 'at http://www.ebi.ac.uk/data/view/ERP00191 1&display=html [27]'
+        exp_out = ['ERP001911']
+        obs_out = _find_accession_ids(txt, 'study')
+        self.assertListEqual(exp_out, obs_out)
 
     def test_find_accession_ids_no_ids(self):
         txt = 'this text has no run ids and no bioproject ids.'


### PR DESCRIPTION
This PR resolves cases where accession IDs were not correctly scraped from publications due to the presence of whitespace characters in the middle of the accession ID sequence.

### Testing
Try and scrape a collection with one of these two publications within: 10.3389/fmicb.2018.02755, 10.1186/s40168-015-0089-2

The former implementation would have returned:
* an error for scraping 10.3389/fmicb.2018.02755, namely `invalid literal for int() with base 10: 'SRP1'`
* the accession `ERP00191` for scraping 10.1186/s40168-015-0089-2

With the changes the following output should be obtained in `study_ids.qza`:
```
ID  DOI
SRP132205   ['10.3389/fmicb.2018.02755']
ERP001911   ['10.1186/s40168-015-0089-2']
```