### PR TITLE
MAINT: update DOI badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 ![CI](https://github.com/bokulich-lab/q2-fondue/actions/workflows/ci.yml/badge.svg)
 [![codecov](https://codecov.io/gh/bokulich-lab/q2-fondue/branch/main/graph/badge.svg?token=UTM4W4B1KW)](https://codecov.io/gh/bokulich-lab/q2-fondue)
 [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.6388476.svg)](https://doi.org/10.5281/zenodo.6388476)
-[![DOI](http://img.shields.io/badge/DOI-10.1101/2021.01.08.425840-B31B1B.svg)](https://doi.org/10.1101/2022.03.22.485322)
+[![DOI](http://img.shields.io/badge/DOI-10.1093/bioinformatics/btac639-B31B1B.svg)](https://doi.org/10.1093/bioinformatics/btac639)
 
 <p>
 <img src="logo.png" height="150" align="left"/>


### PR DESCRIPTION
This PR updates the paper DOI badge to point to the Bioinformatics one, rather than the preprint.