### PR TITLE
Update QIIME 2 versions in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,11 +32,11 @@ conda activate fondue
 
 ### Option 2: Install fondue within existing QIIME 2 environment
 * Install QIIME 2 within a conda environment as described in [the official user documentation](https://docs.qiime2.org/). 
-* Activate the QIIME 2 environment (v2022.8 or higher) and install fondue within:
+* Activate the QIIME 2 environment (v2022.8 or higher) and install fondue within while making sure that the used conda channel matches the version of the QIIME 2 environment (replace below `{ENV_VERSION}` with the version number of your QIIME 2 environment):
 ```
-conda activate qiime2-2022.11
+conda activate qiime2-{ENV_VERSION}
 mamba install -y \
-   -c https://packages.qiime2.org/qiime2/2022.11/tested/ \
+   -c https://packages.qiime2.org/qiime2/{ENV_VERSION}/tested/ \
    -c conda-forge -c bioconda -c defaults \
    q2-fondue
 ```

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ conda install mamba -n base -c conda-forge
 * Create and activate a conda environment with the required dependencies:
 ```shell
 mamba create -y -n fondue \
-   -c https://packages.qiime2.org/qiime2/2022.8/tested/ \
+   -c https://packages.qiime2.org/qiime2/2022.11/tested/ \
    -c conda-forge -c bioconda -c defaults \
    q2cli q2-fondue
 
@@ -32,11 +32,11 @@ conda activate fondue
 
 ### Option 2: Install fondue within existing QIIME 2 environment
 * Install QIIME 2 within a conda environment as described in [the official user documentation](https://docs.qiime2.org/). 
-* Activate the QIIME 2 environment (v2021.4 or higher) and install fondue within:
+* Activate the QIIME 2 environment (v2022.8 or higher) and install fondue within:
 ```
-conda activate qiime2-2022.8
+conda activate qiime2-2022.11
 mamba install -y \
-   -c https://packages.qiime2.org/qiime2/2022.8/tested/ \
+   -c https://packages.qiime2.org/qiime2/2022.11/tested/ \
    -c conda-forge -c bioconda -c defaults \
    q2-fondue
 ```


### PR DESCRIPTION
I was using `q2-fondue` recently and took the liberty of updating the README:
* Updated installation code to latest QIIME 2 version
* Required v2022.8 instead of v2021.4. The QIIME 2 package channel only contains `q2-fondue` starting in 2022.8, and I believe the QIIME 2 environment version should be the same as that of the package channel. (I could be wrong there - though it seems like good practice in any case.)