### PR TITLE
ENH: Add scraper sync note

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ __Note:__ the input TSV file needs to consist of a single column named "ID".
 
 To set these environment variables run the following commands in your terminal for each of the three required variables: `export ZOTERO_TYPE=<your library type>` or create a `.env` file with the environment variable assignment. For the latter option, make sure to ignore this file in version control (add to `.gitignore`). 
 
-__Note:__ To retrieve all required entries from Zotero, you must be logged in.
+__Note:__ To retrieve all required entries from Zotero, you must be logged in. Also, to allow for the `scrape-collection` action to work, make sure you enable file syncing on your Zotero account (see section "File Syncing" [here](https://www.zotero.org/support/sync)) and only attempt to use the action once all attachments were synchronized with your Web Library.
 
 ```shell
 qiime fondue scrape-collection \

--- a/q2_fondue/scraper.py
+++ b/q2_fondue/scraper.py
@@ -387,8 +387,8 @@ def scrape_collection(
         except zotero_errors.ResourceNotFound:
             str_text = ''
             logger.warning(f'Item {attach_key} doesn\'t contain any '
-                           f'full-text content or this item was not synchronized '
-                           f'correctly.')
+                           f'full-text content or this item was not '
+                           f'synchronized correctly.')
 
         # find accession IDs
         for id_type in doi_dicts.keys():

--- a/q2_fondue/scraper.py
+++ b/q2_fondue/scraper.py
@@ -387,7 +387,8 @@ def scrape_collection(
         except zotero_errors.ResourceNotFound:
             str_text = ''
             logger.warning(f'Item {attach_key} doesn\'t contain any '
-                           f'full-text content')
+                           f'full-text content or this item was not synchronized '
+                           f'correctly.')
 
         # find accession IDs
         for id_type in doi_dicts.keys():

--- a/q2_fondue/tests/test_scraper.py
+++ b/q2_fondue/tests/test_scraper.py
@@ -480,7 +480,8 @@ class TestCollectionScraping(TestUtils4CollectionScraping):
             obs_out = scrape_collection("test_collection")
             self.assertIn(
                 "WARNING:q2_fondue.scraper:Item DMJ4AQ48 doesn't contain "
-                "any full-text content or this item was not synchronized correctly.",
+                "any full-text content or this item was not synchronized "
+                "correctly.",
                 cm.output
             )
             for i in range(0, 4):

--- a/q2_fondue/tests/test_scraper.py
+++ b/q2_fondue/tests/test_scraper.py
@@ -480,7 +480,7 @@ class TestCollectionScraping(TestUtils4CollectionScraping):
             obs_out = scrape_collection("test_collection")
             self.assertIn(
                 "WARNING:q2_fondue.scraper:Item DMJ4AQ48 doesn't contain "
-                "any full-text content",
+                "any full-text content or this item was not synchronized correctly.",
                 cm.output
             )
             for i in range(0, 4):


### PR DESCRIPTION
This PR:
* adds a note for how the user can make sure the `scrape-collection` action is run properly. 
* adjusts the warning that is raised in case no attachments were found.
