### PR TITLE
ENH: Fetch restricted access sequences with a repository key

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -75,3 +75,7 @@ target/
 
 fasterq.tmp.*/**
 sratoolkit**/**
+
+# ignore dbGAP permission keys
+**.krt
+**.ngc

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ conda install mamba -n base -c conda-forge
 * Create and activate a conda environment with the required dependencies:
 ```shell
 mamba create -y -n fondue \
-   -c https://packages.qiime2.org/qiime2/2022.11/tested/ \
+   -c https://packages.qiime2.org/qiime2/2023.2/tested/ \
    -c conda-forge -c bioconda -c defaults \
    q2cli q2-fondue
 
@@ -166,7 +166,7 @@ where:
 The resulting artifact `--o-metadata ` will contain a TSV file with all the available metadata fields for all of the requested runs. If metadata for some run IDs failed to download they are returned in the `--o-failed-runs` artifact, which can be directly inputted as `--i-accession-ids` to a subsequent `get-metadata` command. To pass associated DOI names for the failed runs, provide the table of accession IDs with associated DOI names as `--o-linked-doi` to the `get-metadata` command.
 
 ### Fetching sequences
-To get single-read and paired-end sequences associated with a number of IDs, execute this command:
+To get openly accessible single-read and paired-end sequences associated with a number of IDs, execute this command:
 ```shell
 qiime fondue get-sequences \
               --i-accession-ids ids.qza \
@@ -189,6 +189,20 @@ If one of the provided IDs only contains sequences of one type (e.g. single-read
 if none of the requested sequences failed to download, the corresponding artifact will be empty.
 
 If some run IDs failed to download they are returned in the `--o-failed-runs` artifact, which can be directly inputted as `--i-accession-ids` to a subsequent `get-sequence` command.
+
+#### Special case: Fetching restricted access sequences with a dbGAP repository key
+To get access to the respective dbGaP repository key users must first apply for approval and then retrieve the key from dbGAP (see prerequisites described [here](https://www.ncbi.nlm.nih.gov/sra/docs/sra-dbgap-download/)).    
+
+To retrieve sequencing data using the acquired dbGAP repository key, without revealing the sensitive key, set the filepath to the stored key as an environment variable. You can either do this by running the following command in your terminal `export KEY_FILEPATH=<path to key>` or by adding the variable assignment to your `.env` file. For the latter option, make sure to ignore this file in version control (add to `.gitignore`).        
+Having set the filepath of the key as an environment variable you can fetch the sequencing data by running `get-sequences` with the parameter `--p-restricted-access`:
+```shell
+qiime fondue get-sequences \
+              --i-accession-ids ids.qza \
+              --p-email your_email@somewhere.com \
+              --p-restricted-access \
+              --output-dir output_path
+```
+__Note:__ Fetching metadata with a dbGAP repository key is not supported. Hence, this flag is only available in the `get-sequences` action (and not in the `get-metadata` and `get-all` actions).
 
 ### Fetching metadata and sequences
 To fetch both sequence-associated metadata and sequences associated with the provided IDs, execute this command:

--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ where:
 The resulting artifact `--o-metadata ` will contain a TSV file with all the available metadata fields for all of the requested runs. If metadata for some run IDs failed to download they are returned in the `--o-failed-runs` artifact, which can be directly inputted as `--i-accession-ids` to a subsequent `get-metadata` command. To pass associated DOI names for the failed runs, provide the table of accession IDs with associated DOI names as `--o-linked-doi` to the `get-metadata` command.
 
 ### Fetching sequences
-To get openly accessible single-read and paired-end sequences associated with a number of IDs, execute this command:
+To get openly accessible single- and paired-end sequences associated with a number of IDs, execute this command:
 ```shell
 qiime fondue get-sequences \
               --i-accession-ids ids.qza \

--- a/q2_fondue/plugin_setup.py
+++ b/q2_fondue/plugin_setup.py
@@ -49,7 +49,7 @@ common_params = {
 
 common_param_descr = {
     'email': 'Your e-mail address (required by NCBI).',
-    'n_jobs': 'Number of concurrent download jobs (default: 1).',
+    'n_jobs': 'Number of concurrent download jobs.',
     'log_level': 'Logging level.'
 }
 
@@ -131,9 +131,9 @@ plugin.methods.register_function(
     input_descriptions={**common_input_descriptions},
     parameter_descriptions={
         **common_param_descr,
-        'retries': 'Number of retries to fetch sequences (default: 2).',
+        'retries': 'Number of retries to fetch sequences.',
         'restricted_access': 'If sequence fetch requires dbGaP repository '
-        'key (default=False).'
+        'key.'
     },
     output_descriptions={
         'single_reads': output_descriptions['single_reads'],
@@ -165,7 +165,7 @@ plugin.pipelines.register_function(
     },
     parameter_descriptions={
         **common_param_descr,
-        'retries': 'Number of retries to fetch sequences (default: 2).'
+        'retries': 'Number of retries to fetch sequences.'
     },
     output_descriptions={
         'metadata': output_descriptions['metadata'],

--- a/q2_fondue/plugin_setup.py
+++ b/q2_fondue/plugin_setup.py
@@ -13,7 +13,7 @@ from q2_types.per_sample_sequences import (
 from q2_types.sample_data import SampleData
 from qiime2.core.type import TypeMatch
 from qiime2.plugin import (
-    Plugin, Citations, Choices, Str, Int, List, Range
+    Plugin, Citations, Choices, Str, Int, List, Range, Bool
 )
 
 from q2_fondue import __version__
@@ -120,7 +120,8 @@ plugin.methods.register_function(
     inputs={**common_inputs},
     parameters={
         **common_params,
-        'retries': Int % Range(0, None)
+        'retries': Int % Range(0, None),
+        'restricted_access': Bool
     },
     outputs=[
         ('single_reads', SampleData[SequencesWithQuality]),
@@ -131,6 +132,8 @@ plugin.methods.register_function(
     parameter_descriptions={
         **common_param_descr,
         'retries': 'Number of retries to fetch sequences (default: 2).',
+        'restricted_access': 'If sequence fetch requires dbGaP repository '
+        'key (default=False).'
     },
     output_descriptions={
         'single_reads': output_descriptions['single_reads'],

--- a/q2_fondue/sequences.py
+++ b/q2_fondue/sequences.py
@@ -49,10 +49,10 @@ def _run_cmd_fasterq(
     else:
         key_params = []
 
-    cmd_prefetch = ['prefetch', '-X', 'u', '-O', acc] + key_params + [acc]
+    cmd_prefetch = ['prefetch', '-X', 'u', '-O', acc, *key_params, acc]
     cmd_fasterq = [
-        'fasterq-dump', '-e', str(threads), '--size-check', 'on', '-x'] + \
-        key_params + [acc]
+        'fasterq-dump', '-e', str(threads), '--size-check', 'on', '-x',
+        *key_params, acc]
 
     result = subprocess.run(
         cmd_prefetch, text=True, capture_output=True, cwd=output_dir)
@@ -93,9 +93,9 @@ def _run_fasterq_dump_for_all(
     Args:
         accession_ids (list): List of all run IDs to be fetched.
         tmpdirname (str): Name of temporary directory to store the data.
-        threads (int, default=1): Number of threads to be used in parallel.
-        key_file (str, default=''): Filepath to dbGaP repository key.
-        retries (int, default=2): Number of retries to fetch sequences.
+        threads (int): Number of threads to be used in parallel.
+        key_file (str): Filepath to dbGaP repository key.
+        retries (int): Number of retries to fetch sequences.
         fetched_queue (multiprocessing.Queue): Queue communicating IDs
             that were successfully fetched.
         done_queue (SyncManager.Queue): Queue communicating filenames

--- a/q2_fondue/sequences.py
+++ b/q2_fondue/sequences.py
@@ -371,6 +371,12 @@ def get_sequences(
         if restricted_access:
             dotenv.load_dotenv()
             key_file = os.getenv('KEY_FILEPATH')
+            if not os.path.isfile(key_file):
+                raise ValueError(
+                    'The provided dbGAP repository key filepath does not '
+                    'exist. Please check your environment variable '
+                    'KEY_FILEPATH.'
+                )
         else:
             key_file = ''
         # run fasterq-dump for all accessions

--- a/q2_fondue/tests/test_get_all.py
+++ b/q2_fondue/tests/test_get_all.py
@@ -89,7 +89,7 @@ class TestGetAll(SequenceTests):
         # function call assertions for get_sequences within
         mock_proc.assert_has_calls([
             call(target=_run_fasterq_dump_for_all, args=(
-                [acc_id], mock_tmpdir.return_value.name, 1, 1,
+                [acc_id], mock_tmpdir.return_value.name, 1, '', 1,
                 ANY, ANY), daemon=True),
             call(target=_process_downloaded_sequences, args=(
                 mock_tmpdir.return_value.name, ANY, ANY, 1), daemon=True),
@@ -178,7 +178,7 @@ class TestGetAll(SequenceTests):
         # function call assertions for get_sequences within
         mock_proc.assert_has_calls([
             call(target=_run_fasterq_dump_for_all, args=(
-                [acc_ids[0]], mock_tmpdir.return_value.name, 1, 0,
+                [acc_ids[0]], mock_tmpdir.return_value.name, 1, '', 0,
                 ANY, ANY), daemon=True),
             call(target=_process_downloaded_sequences, args=(
                 mock_tmpdir.return_value.name, ANY, ANY, 1), daemon=True),

--- a/q2_fondue/tests/test_sequences.py
+++ b/q2_fondue/tests/test_sequences.py
@@ -869,6 +869,7 @@ class TestSequenceFetching(SequenceTests):
             )
 
     @patch.dict(os.environ, {"KEY_FILEPATH": "path/to/key.ngc"})
+    @patch('dotenv.load_dotenv')
     @patch('os.path.isfile')
     @patch('q2_fondue.sequences.Process')
     @patch('q2_fondue.sequences.Pool')
@@ -876,7 +877,7 @@ class TestSequenceFetching(SequenceTests):
     @patch('tempfile.TemporaryDirectory')
     def test_get_sequences_restricted_access(
         self, mock_tmpdir, mock_announce, mock_pool, mock_proc,
-        mock_isfile
+        mock_isfile, mock_load_dotenv
     ):
         acc_id = 'SRR123456'
         ls_file_names = [f'{acc_id}.fastq', f'{acc_id}.sra']

--- a/q2_fondue/tests/test_sequences.py
+++ b/q2_fondue/tests/test_sequences.py
@@ -119,7 +119,7 @@ class TestUtils4SequenceFetching(SequenceTests):
         ]
 
         _run_fasterq_dump_for_all(
-            ls_acc_ids, test_temp_dir.name, threads=6,
+            ls_acc_ids, test_temp_dir.name, threads=6, key_file='',
             retries=0, fetched_queue=self.fetched_q,
             done_queue=self.processed_q
         )
@@ -153,7 +153,43 @@ class TestUtils4SequenceFetching(SequenceTests):
         ]
 
         _run_fasterq_dump_for_all(
-            ls_acc_ids, test_temp_dir.name, threads=6,
+            ls_acc_ids, test_temp_dir.name, threads=6, key_file='',
+            retries=0, fetched_queue=self.fetched_q,
+            done_queue=self.processed_q
+        )
+        mock_subprocess.assert_has_calls([
+            call(exp_prefetch, text=True,
+                 capture_output=True, cwd=test_temp_dir.name),
+            call(exp_fasterq, text=True,
+                 capture_output=True, cwd=test_temp_dir.name)
+        ])
+        mock_rm.assert_called_with(
+            os.path.join(test_temp_dir.name, ls_acc_ids[0])
+        )
+        mock_space_check.assert_not_called()
+
+    @patch('shutil.rmtree')
+    @patch('subprocess.run', return_value=MagicMock(returncode=0))
+    @patch('q2_fondue.sequences._has_enough_space', return_value=True)
+    def test_run_cmd_fasterq_with_restricted_key(
+            self, mock_space_check, mock_subprocess, mock_rm
+    ):
+        test_temp_dir = self.move_files_2_tmp_dir(['testaccA.fastq'])
+        os.makedirs(f'{test_temp_dir.name}/testaccA')
+
+        ls_acc_ids = ['testaccA']
+        key = 'mykey.ngc'
+        exp_prefetch = [
+            'prefetch', '-X', 'u', '-O', ls_acc_ids[0], '--ngc', key,
+            ls_acc_ids[0]
+        ]
+        exp_fasterq = [
+            'fasterq-dump', '-e', str(6), '--size-check', 'on', '-x',
+            '--ngc', key, ls_acc_ids[0]
+        ]
+
+        _run_fasterq_dump_for_all(
+            ls_acc_ids, test_temp_dir.name, threads=6, key_file=key,
             retries=0, fetched_queue=self.fetched_q,
             done_queue=self.processed_q
         )
@@ -187,7 +223,7 @@ class TestUtils4SequenceFetching(SequenceTests):
 
         with self.assertLogs('q2_fondue.sequences', level='INFO') as cm:
             _run_fasterq_dump_for_all(
-                ls_acc_ids, test_temp_dir.name, threads=6,
+                ls_acc_ids, test_temp_dir.name, threads=6, key_file='',
                 retries=0, fetched_queue=self.fetched_q,
                 done_queue=self.processed_q
             )
@@ -219,7 +255,7 @@ class TestUtils4SequenceFetching(SequenceTests):
 
         with self.assertLogs('q2_fondue.sequences', level='INFO') as cm:
             _run_fasterq_dump_for_all(
-                ls_acc_ids, test_temp_dir.name, threads=6,
+                ls_acc_ids, test_temp_dir.name, threads=6, key_file='',
                 retries=1, fetched_queue=self.fetched_q,
                 done_queue=self.processed_q
             )
@@ -255,7 +291,7 @@ class TestUtils4SequenceFetching(SequenceTests):
 
         with self.assertLogs('q2_fondue.sequences', level='INFO') as cm:
             _run_fasterq_dump_for_all(
-                ls_acc_ids, test_temp_dir.name, threads=6,
+                ls_acc_ids, test_temp_dir.name, threads=6, key_file='',
                 retries=1, fetched_queue=self.fetched_q,
                 done_queue=self.processed_q
             )
@@ -290,7 +326,7 @@ class TestUtils4SequenceFetching(SequenceTests):
 
         with self.assertLogs('q2_fondue.sequences', level='INFO') as cm:
             _run_fasterq_dump_for_all(
-                ls_acc_ids, test_temp_dir.name, threads=6,
+                ls_acc_ids, test_temp_dir.name, threads=6, key_file='',
                 retries=2, fetched_queue=self.fetched_q,
                 done_queue=self.processed_q
             )
@@ -329,7 +365,7 @@ class TestUtils4SequenceFetching(SequenceTests):
 
         with self.assertLogs('q2_fondue.sequences', level='INFO') as cm:
             _run_fasterq_dump_for_all(
-                ls_acc_ids, test_temp_dir.name, threads=6,
+                ls_acc_ids, test_temp_dir.name, threads=6, key_file='',
                 retries=2, fetched_queue=self.fetched_q,
                 done_queue=self.processed_q
             )
@@ -371,7 +407,7 @@ class TestUtils4SequenceFetching(SequenceTests):
 
         with self.assertLogs('q2_fondue.sequences', level='INFO') as cm:
             _run_fasterq_dump_for_all(
-                ls_acc_ids, test_temp_dir.name, threads=6,
+                ls_acc_ids, test_temp_dir.name, threads=6, key_file='',
                 retries=1, fetched_queue=self.fetched_q,
                 done_queue=self.processed_q
             )
@@ -628,7 +664,7 @@ class TestSequenceFetching(SequenceTests):
             )
             mock_proc.assert_has_calls([
                 call(target=_run_fasterq_dump_for_all, args=(
-                    [acc_id], mock_tmpdir.return_value.name, 1, 0,
+                    [acc_id], mock_tmpdir.return_value.name, 1, '', 0,
                     ANY, ANY), daemon=True),
                 call(target=_process_downloaded_sequences, args=(
                     mock_tmpdir.return_value.name, ANY, ANY, 1), daemon=True)
@@ -673,7 +709,7 @@ class TestSequenceFetching(SequenceTests):
             )
             mock_proc.assert_has_calls([
                 call(target=_run_fasterq_dump_for_all, args=(
-                    [acc_id], mock_tmpdir.return_value.name, 1, 0,
+                    [acc_id], mock_tmpdir.return_value.name, 1, '', 0,
                     ANY, ANY), daemon=True),
                 call(target=_process_downloaded_sequences, args=(
                     mock_tmpdir.return_value.name, ANY, ANY, 1), daemon=True),
@@ -717,7 +753,7 @@ class TestSequenceFetching(SequenceTests):
         mock_proc.assert_has_calls([
             call(target=_run_fasterq_dump_for_all, args=(
                 ['SRR123456', 'SRR123457'], mock_tmpdir.return_value.name, 1,
-                0, ANY, ANY), daemon=True),
+                '', 0, ANY, ANY), daemon=True),
             call(target=_process_downloaded_sequences, args=(
                 mock_tmpdir.return_value.name, ANY, ANY, 1), daemon=True),
         ])
@@ -756,7 +792,7 @@ class TestSequenceFetching(SequenceTests):
         )
         mock_proc.assert_has_calls([
             call(target=_run_fasterq_dump_for_all, args=(
-                [run_id], mock_tmpdir.return_value.name, 1,
+                [run_id], mock_tmpdir.return_value.name, 1, '',
                 0, ANY, ANY), daemon=True),
             call(target=_process_downloaded_sequences, args=(
                 mock_tmpdir.return_value.name, ANY, ANY, 1), daemon=True),
@@ -794,7 +830,7 @@ class TestSequenceFetching(SequenceTests):
         mock_proc.assert_has_calls([
             call(target=_run_fasterq_dump_for_all, args=(
                 ['SRR123456', 'SRR123457'], mock_tmpdir.return_value.name, 1,
-                0, ANY, ANY), daemon=True),
+                '', 0, ANY, ANY), daemon=True),
             call(target=_process_downloaded_sequences, args=(
                 mock_tmpdir.return_value.name, ANY, ANY, 1), daemon=True),
         ])

--- a/tutorial/tutorial.md
+++ b/tutorial/tutorial.md
@@ -187,6 +187,8 @@ qiime fondue get-sequences \
 
 > *Note:* We can also add the `--p-n-jobs` and `--p-retries`  parameters in this command (see [`get-metadata`](#fetching-only-metadata) and [`get-all`](#fetching-sequences-and-corresponding-metadata-together) for more explanations).
 
+> *Note:* To fetch restricted access sequencing data with a dbGAP repository key, see the instructions in the `README.md` [here](../README.md####special-case:-fetching-restriced-access-sequences-with-a-dbGAP-repository-key).
+
 #### Scraping IDs from a Zotero web library collection
 
 For now we have assumed that a file exists with the accession IDs, for which we want to fetch the sequences and corresponding metadata, namely `metadata_file.qza`. If you want to scrape the run, study, BioProject, experiment and samples IDs with associated DOI names from an existing Zotero web library collection, you can use the `scrape-collection` method. Before running it, you have to set three environment variables linked to your Zotero account:


### PR DESCRIPTION
closes #155 


### Testing
Using the freely available test `key prj_phs710EA_test.ngc` try and fetch the accession ID `SRR1219902`:
1) Download the key from [here](https://ftp.ncbi.nlm.nih.gov/sra/examples/decrypt_examples/prj_phs710EA_test.ngc).
2) Import the above run ID as a `NCBIAccessionIDs` artifact.
3) Follow the instructions in the README [here](https://github.com/bokulich-lab/q2-fondue/blob/bfff4d7bb64ee6e9a05f2bf6a1e97b2c669638b9/README.md?plain=1#L193-L205).

Beware, the download might take rather long (in my case it was ~1-2 hrs) as the freely available key matches a sequencing file of 13.8 GB. 


**Note:** The GitHub action is failing due to a temporarily expired certificate for packages.qiime2.org.
