### PR TITLE
FIX: Pandas deprecations

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM mambaorg/micromamba
 ARG MAMBA_DOCKERFILE_ACTIVATE=1
-RUN micromamba install -y -c https://packages.qiime2.org/qiime2/2023.2/tested/ \
+RUN micromamba install -y -c https://packages.qiime2.org/qiime2/2023.7/tested/ \
 	-c conda-forge -c bioconda -c defaults \
 	q2cli q2-fondue
 ENV PATH /opt/conda/bin:$PATH

--- a/README.md
+++ b/README.md
@@ -18,12 +18,13 @@ For both options 1 and 2 make sure to start by installing [mamba](https://mamba.
 ```shell
 conda install mamba -n base -c conda-forge
 ```
+Also, don't forget to run the mandatory configuration step [at the end]((#mandatory-configuration-for-both-options-1-and-2))!
 
 ### Option 1: Minimal fondue environment:
 * Create and activate a conda environment with the required dependencies:
 ```shell
 mamba create -y -n fondue \
-   -c https://packages.qiime2.org/qiime2/2023.2/tested/ \
+   -c https://packages.qiime2.org/qiime2/2023.7/tested/ \
    -c conda-forge -c bioconda -c defaults \
    q2cli q2-fondue
 
@@ -71,15 +72,15 @@ To find out which temporary directory is used by Qiime 2, you can run `echo $TMP
 ### Available actions
 q2-fondue provides a couple of actions to fetch and manipulate nucleotide sequencing data and related metadata from SRA as well as an action to scrape run, study, BioProject, experiment and sample IDs from a Zotero web library. Below you will find a list of available actions and their short descriptions.
 
-| Action               | Description                                                              |
-|----------------------|--------------------------------------------------------------------------|
-| `get-sequences`      | Fetch sequences by IDs[*] from the SRA repository.        |
-| `get-metadata`       | Fetch metadata by IDs[*] from the SRA repository.         |
-| `get-all`            | Fetch sequences and metadata by IDs[*] from the SRA repo. |
-| `get-ids-from-query` | Find SRA run accession IDs based on a search query. |
-| `merge-metadata`     | Merge several metadata files into a single metadata object.              |
-| `combine-seqs`       | Combine sequences from multiple artifacts into a single artifact.        |
-| `scrape-collection`  | Scrape Zotero collection for IDs[*] and associated DOI names.|
+| Action               | Description                                                       |
+|----------------------|-------------------------------------------------------------------|
+| `get-sequences`      | Fetch sequences by IDs[*] from the SRA repository.                |
+| `get-metadata`       | Fetch metadata by IDs[*] from the SRA repository.                 |
+| `get-all`            | Fetch sequences and metadata by IDs[*] from the SRA repo.         |
+| `get-ids-from-query` | Find SRA run accession IDs based on a search query.               |
+| `merge-metadata`     | Merge several metadata files into a single metadata object.       |
+| `combine-seqs`       | Combine sequences from multiple artifacts into a single artifact. |
+| `scrape-collection`  | Scrape Zotero collection for IDs[*] and associated DOI names.     |
 
 [*]: Supported IDs include run, study, BioProject, experiment and study IDs.
 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Also, don't forget to run the mandatory configuration step [at the end]((#mandat
 * Create and activate a conda environment with the required dependencies:
 ```shell
 mamba create -y -n fondue \
-   -c https://packages.qiime2.org/qiime2/2023.7/tested/ \
+   -c https://packages.qiime2.org/qiime2/2023.5/tested/ \
    -c conda-forge -c bioconda -c defaults \
    q2cli q2-fondue
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ conda install mamba -n base -c conda-forge
 * Create and activate a conda environment with the required dependencies:
 ```shell
 mamba create -y -n fondue \
-   -c https://packages.qiime2.org/qiime2/2023.5/tested/ \
+   -c https://packages.qiime2.org/qiime2/2023.7/tested/ \
    -c conda-forge -c bioconda -c defaults \
    q2cli q2-fondue
 

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ vdb-config --proxy <your proxy URL> --proxy-disable no
 Use containerization to integrate q2-fondue into your pipelines, or simply run reproducibly without the need for heavyweight package managers. [Read more about Docker here.](https://www.docker.com/get-started/)
  
 * Install [Docker](https://docs.docker.com/engine/install/) with the linked instructions
-* Pull the [q2-fondue Docker image](https://hub.docker.com/layers/linathekim/q2-fondue/2023.7/images/<UPDATEDLINKHERE>):
+* Pull the [q2-fondue Docker image](https://hub.docker.com/layers/linathekim/q2-fondue/2023.7/images/sha256-f5d26959ac035811a8f34e2a46f6cc381f9a4ce21b3604a196c1ee176ba708e7?context=repo):
 ```shell
 docker pull linathekim/q2-fondue:2023.7
 ```

--- a/README.md
+++ b/README.md
@@ -18,7 +18,6 @@ For both options 1 and 2 make sure to start by installing [mamba](https://mamba.
 ```shell
 conda install mamba -n base -c conda-forge
 ```
-Also, don't forget to run the mandatory configuration step [at the end]((#mandatory-configuration-for-both-options-1-and-2))!
 
 ### Option 1: Minimal fondue environment:
 * Create and activate a conda environment with the required dependencies:
@@ -30,6 +29,7 @@ mamba create -y -n fondue \
 
 conda activate fondue
 ```
+Now, don't forget to run [the mandatory configuration step](#mandatory-configuration-for-both-options-1-and-2)!
 
 ### Option 2: Install fondue within existing QIIME 2 environment
 * Install QIIME 2 within a conda environment as described in [the official user documentation](https://docs.qiime2.org/). 
@@ -41,6 +41,7 @@ mamba install -y \
    -c conda-forge -c bioconda -c defaults \
    q2-fondue
 ```
+Now, don't forget to run [the mandatory configuration step](#mandatory-configuration-for-both-options-1-and-2)!
 
 ### Mandatory configuration for both options 1 and 2
 * Refresh the QIIME 2 CLI cache and see that everything worked:

--- a/README.md
+++ b/README.md
@@ -67,9 +67,9 @@ vdb-config --proxy <your proxy URL> --proxy-disable no
 Use containerization to integrate q2-fondue into your pipelines, or simply run reproducibly without the need for heavyweight package managers. [Read more about Docker here.](https://www.docker.com/get-started/)
  
 * Install [Docker](https://docs.docker.com/engine/install/) with the linked instructions
-* Pull the [q2-fondue Docker image](https://hub.docker.com/layers/linathekim/q2-fondue/2023.2/images/sha256-214d0575eb4eaf435c5c4a7d29edf0fc082e47999b884b52a173f2ec469975f2?context=repo):
+* Pull the [q2-fondue Docker image](https://hub.docker.com/layers/linathekim/q2-fondue/2023.7/images/<UPDATEDLINKHERE>):
 ```shell
-docker pull linathekim/q2-fondue:2023.2
+docker pull linathekim/q2-fondue:2023.7
 ```
 * Within the container, refresh the QIIME 2 CLI cache to see that everything worked:
 ```shell

--- a/q2_fondue/get_all.py
+++ b/q2_fondue/get_all.py
@@ -6,16 +6,16 @@
 # The full license is in the file LICENSE, distributed with this software.
 # ----------------------------------------------------------------------------
 
-import threading
+import qiime2 as q2
 
 import pandas as pd
-import qiime2 as q2
-from qiime2 import Artifact
+import threading
 
 from q2_fondue.utils import handle_threaded_exception
+from qiime2 import Artifact
+
 
 threading.excepthook = handle_threaded_exception
-
 
 def get_all(
         ctx, accession_ids, email, n_jobs=1, retries=2, log_level='INFO',

--- a/q2_fondue/get_all.py
+++ b/q2_fondue/get_all.py
@@ -6,14 +6,13 @@
 # The full license is in the file LICENSE, distributed with this software.
 # ----------------------------------------------------------------------------
 
-import qiime2 as q2
-
-import pandas as pd
 import threading
 
-from q2_fondue.utils import handle_threaded_exception
+import pandas as pd
+import qiime2 as q2
 from qiime2 import Artifact
 
+from q2_fondue.utils import handle_threaded_exception
 
 threading.excepthook = handle_threaded_exception
 
@@ -40,8 +39,8 @@ def get_all(
     seq_single, seq_paired, failed_ids, = get_sequences(
         run_ids, email, retries, n_jobs, log_level
     )
-
-    failed_ids_df = failed_ids_df.append(failed_ids.view(pd.DataFrame))
+    failed_ids_df = pd.concat(
+        [failed_ids_df, failed_ids.view(pd.DataFrame)])
     if failed_ids_df.shape[0] > 0:
         failed_ids = Artifact.import_data('SRAFailedIDs', failed_ids_df)
 

--- a/q2_fondue/get_all.py
+++ b/q2_fondue/get_all.py
@@ -17,6 +17,7 @@ from qiime2 import Artifact
 
 threading.excepthook = handle_threaded_exception
 
+
 def get_all(
         ctx, accession_ids, email, n_jobs=1, retries=2, log_level='INFO',
         linked_doi=None):

--- a/q2_fondue/tests/test_query.py
+++ b/q2_fondue/tests/test_query.py
@@ -28,7 +28,7 @@ class TestQuery(SequenceTests):
         obs_ids, = fondue.actions.get_ids_from_query(
             query, 'fake@email.com', 1, 'DEBUG'
         )
-        exp_ids = pd.DataFrame(index=pd.Index(['SRR123', 'SRR234'], name='ID'))
+        exp_ids = pd.DataFrame(index=pd.Index(['SRR123', 'SRR234'], name='ID'), columns=[], )
 
         mock_ids.assert_called_once_with(
             'fake@email.com', 1, None, query, 'biosample', 'DEBUG'

--- a/q2_fondue/tests/test_query.py
+++ b/q2_fondue/tests/test_query.py
@@ -28,7 +28,8 @@ class TestQuery(SequenceTests):
         obs_ids, = fondue.actions.get_ids_from_query(
             query, 'fake@email.com', 1, 'DEBUG'
         )
-        exp_ids = pd.DataFrame(index=pd.Index(['SRR123', 'SRR234'], name='ID'), columns=[], )
+        exp_ids = pd.DataFrame(
+            index=pd.Index(['SRR123', 'SRR234'], name='ID'), columns=[], )
 
         mock_ids.assert_called_once_with(
             'fake@email.com', 1, None, query, 'biosample', 'DEBUG'

--- a/q2_fondue/types/_transformer.py
+++ b/q2_fondue/types/_transformer.py
@@ -23,7 +23,7 @@ def _meta_fmt_to_metadata(ff):
 
 def _meta_fmt_to_series(ff):
     with ff.open() as fh:
-        s = pd.read_csv(fh, header=0, dtype='str', squeeze=True)
+        s = pd.read_csv(fh, header=0, dtype='str').squeeze()
         return s
 
 

--- a/q2_fondue/types/_transformer.py
+++ b/q2_fondue/types/_transformer.py
@@ -21,12 +21,6 @@ def _meta_fmt_to_metadata(ff):
         return qiime2.Metadata(df)
 
 
-def _meta_fmt_to_series(ff):
-    with ff.open() as fh:
-        s = pd.read_csv(fh, header=0, dtype='str').squeeze()
-        return s
-
-
 def _series_to_meta_fmt(data: pd.Series, meta_fmt):
     with meta_fmt.open() as fh:
         data.to_csv(fh, sep='\t', header=True, index=False)

--- a/q2_fondue/types/tests/test_types_formats_transformers.py
+++ b/q2_fondue/types/tests/test_types_formats_transformers.py
@@ -178,7 +178,7 @@ class TestTransformers(TestPluginBase):
         ncbi_ids_path = self.get_data_path('ncbi-ids-runs.tsv')
         self.ncbi_ids = NCBIAccessionIDsFormat(ncbi_ids_path, mode='r')
         self.ncbi_ids_ser = pd.read_csv(
-            ncbi_ids_path, header=0, dtype='str', squeeze=True)
+            ncbi_ids_path, header=0, dtype='str').squeeze()
         self.ncbi_ids_df = pd.read_csv(
             ncbi_ids_path, sep='\t', header=0, index_col=0, dtype='str')
 
@@ -234,8 +234,7 @@ class TestTransformers(TestPluginBase):
         self.assertIsInstance(obs, NCBIAccessionIDsFormat)
 
         obs = pd.read_csv(
-            str(obs), header=0, dtype='str', squeeze=True
-        )
+            str(obs), header=0, dtype='str').squeeze()
         pd.testing.assert_series_equal(obs, self.ncbi_ids_ser)
 
     def test_dataframe_to_ncbi_accession_ids(self):


### PR DESCRIPTION
This PR ensures forward compatibility with pandas v2.0 and maintains usablility with pandas version <2.0. It fixes #160.

**Note on testing:**
The below test should fail when installing q2-fondue from channel "https://packages.qiime2.org/qiime2/2023.2/tested/" as currently described in the main channel `README.md` file (and done in the Docker image). The test works without errors when using the updated code.       
Using q2-fondue from channel "https://packages.qiime2.org/qiime2/2023.7/tested/" the code works independently (code from main channel or this PR).

* Follow the instructions to install the minimal conda environment in the `README.md` file.
* Fetch both sequence and metadata for a defined accession ID (e.g. test A below) and/or fetch accession IDs from a query of your choice.


Test A:
```
echo -e "id\nERR1698166" > file.tsv
qiime tools import  \
	--type NCBIAccessionIDs  \
	--input-path file.tsv  \
	--output-path file.qza
qiime fondue get-all  \
	--i-accession-ids file.qza  \
	--p-email your_email@somewhere.com  \
	--p-retries 0  \
	--output-dir file-output  \
	--verbose
```

**Note before merging**
- [x] Before merging this PR, we should update the Docker image and the link in the README.