### PR TITLE
MAINT: use tempfiles in tests

### DIFF
--- a/q2_fondue/tests/test_utils.py
+++ b/q2_fondue/tests/test_utils.py
@@ -8,6 +8,7 @@
 import gzip
 import os
 import signal
+import tempfile
 import threading
 import unittest
 from threading import Thread
@@ -133,16 +134,17 @@ class TestSRAUtils(TestPluginBase):
 
     def test_rewrite_fastq(self):
         file_in = self.get_data_path('SRR123456.fastq')
-        file_out = self.get_data_path('SRR123456.fastq.gz')
+        file_out = tempfile.NamedTemporaryFile()
 
-        _rewrite_fastq(file_in, file_out)
+        _rewrite_fastq(file_in, file_out.name)
 
-        with open(file_in, 'rb') as fin, gzip.open(file_out, 'r') as fout:
+        with (open(file_in, 'rb') as fin,
+              gzip.open(file_out.name, 'r') as fout):
             for lin, lout in zip(fin.readlines(), fout.readlines()):
                 self.assertEqual(lin, lout)
 
         # clean up
-        os.remove(file_out)
+        file_out.close()
 
 
 if __name__ == "__main__":

--- a/q2_fondue/tests/test_utils.py
+++ b/q2_fondue/tests/test_utils.py
@@ -138,10 +138,10 @@ class TestSRAUtils(TestPluginBase):
 
         _rewrite_fastq(file_in, file_out.name)
 
-        with (open(file_in, 'rb') as fin,
-              gzip.open(file_out.name, 'r') as fout):
-            for lin, lout in zip(fin.readlines(), fout.readlines()):
-                self.assertEqual(lin, lout)
+        with open(file_in, 'rb') as fin:
+            with gzip.open(file_out.name, 'r') as fout:
+                for lin, lout in zip(fin.readlines(), fout.readlines()):
+                    self.assertEqual(lin, lout)
 
         # clean up
         file_out.close()


### PR DESCRIPTION
Due to some changes within the `get_data_path` method of the TestPlugin class, it is not anymore possible to use that method to point at non-existent files - temporary files should be used instead. This PR updates the one test to observe this new behaviour.